### PR TITLE
Add numexpr for MKL_INFO

### DIFF
--- a/scooby/extras.py
+++ b/scooby/extras.py
@@ -13,9 +13,15 @@ try:
     import mkl
 except ImportError:
     mkl = False
+try:
+    import numexpr
+except ImportError:
+    numexpr = False
 
-# Get mkl info, if available
+# Get mkl info from numexpr or mkl, if available
 if mkl:
     MKL_INFO = mkl.get_version_string()
+elif numexpr:
+    MKL_INFO = numexpr.get_vml_version()
 else:
     MKL_INFO = False


### PR DESCRIPTION
`MKL_INFO` is very interesting. Unfortunately, most people do not have `mkl` installed explicitly. One other way to get the info is from `numexpr`, which is added by this PR. We might add more possibilities when we find out about them.