### PR TITLE
Adjust default text_width

### DIFF
--- a/scooby/report.py
+++ b/scooby/report.py
@@ -61,6 +61,10 @@ class PlatformInfo:
             return TOTAL_RAM
         return 'unknown'
 
+    @property
+    def date(self):
+        return time.strftime('%a %b %d %H:%M:%S %Y %Z')
+
 
 
 class PythonInfo:
@@ -247,8 +251,22 @@ class Report(PlatformInfo, PythonInfo):
         text = '\n' + self.text_width*'-' + '\n'
 
         # Date and time info as title
-        text += time.strftime('  Date: %a %b %d %H:%M:%S %Y %Z')
-        text += '\n  Platform: ' + self.platform + '\n'
+        date_text = '  Date: '
+        mult = 0
+        indent = len(date_text)
+        for txt in textwrap.wrap(self.date, self.text_width-indent):
+            date_text += ' '*mult + txt + '\n'
+            mult = indent
+        text += date_text
+
+        # Platform info
+        platform_text = '  Platform: '
+        mult = 0
+        indent = len(platform_text)
+        for txt in textwrap.wrap(self.platform, self.text_width-indent):
+            platform_text += ' '*mult + txt + '\n'
+            mult = indent
+        text += platform_text
 
         text += '\n'
 
@@ -334,7 +352,7 @@ class Report(PlatformInfo, PythonInfo):
         html = "<table style='border: 3px solid #ddd;'>\n"
 
         # Date and time info as title
-        html = colspan(html, time.strftime('%a %b %d %H:%M:%S %Y %Z'),
+        html = colspan(html, self.date,
                        self.ncol, 0)
 
         ############ Platform/OS details ############

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -233,7 +233,7 @@ class Report(PlatformInfo, PythonInfo):
     def __init__(self, core=None,
                        optional=('numpy', 'scipy', 'IPython', 'matplotlib',),
                        additional=None,
-                       ncol=3, text_width=54):
+                       ncol=3, text_width=80):
         PythonInfo.__init__(self, core=core, optional=optional,
                             additional=additional)
         self.ncol = int(ncol)


### PR DESCRIPTION
I have no idea why I have `text_width=54` in the versions-script (empymod, emg3d, SimPEG). There must have been a reason. I think too keep it compact.

However, now scooby has several large outputs that then break line (`[GCC 7.3.0]` in the example below) or overflow (`-with-debian-buster-sid` in the example below).

This PR sets the default width to 80, which is usually a minimum terminal width; default flake8-width etc.

![IPython: Codes-scooby_001](https://user-images.githubusercontent.com/8020943/60247322-c18e9300-98c0-11e9-918e-8199b0815814.png)
