### PR TITLE
Report Scooby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ script:
   - python -c "import scooby, mock; print(scooby.investigate(additional=[mock,]))"
   - python -c "import scooby, mock; print(scooby.investigate(additional=mock))"
   - python -c "import scooby, mock; print(scooby.investigate(additional=mock)._repr_html_())"
+  # Test sorting
+  - python -c "import scooby; print(scooby.investigate(additional=['collections', 'foo', 'aaa'], sort=True))"
 
 notifications:
   email:

--- a/scooby/__init__.py
+++ b/scooby/__init__.py
@@ -1,11 +1,11 @@
+# These are our default optional packages to investigate
+SCOOBY_PACKAGES = ['numpy', 'scipy', 'IPython', 'matplotlib', 'scooby']
+
 # coding=utf-8
 from scooby.extras import MKL_INFO, TOTAL_RAM
 from scooby.knowledge import VERSION_ATTRIBUTES
 from scooby.mysteries import in_ipython, in_ipykernel
 from scooby.report import Report
-
-# These are our default optional packages to investigate
-SCOOBY_PACKAGES = ['numpy', 'scipy', 'IPython', 'matplotlib', 'scooby']
 
 
 def investigate(core=None,

--- a/scooby/__init__.py
+++ b/scooby/__init__.py
@@ -4,9 +4,12 @@ from scooby.knowledge import VERSION_ATTRIBUTES
 from scooby.mysteries import in_ipython, in_ipykernel
 from scooby.report import Report
 
+# These are our default optional packages to investigate
+SCOOBY_PACKAGES = ['numpy', 'scipy', 'IPython', 'matplotlib', 'scooby']
+
 
 def investigate(core=None,
-                optional=('numpy', 'scipy', 'IPython', 'matplotlib',),
+                optional=SCOOBY_PACKAGES,
                 additional=None,
                 ncol=3, text_width=54):
     """

--- a/scooby/__init__.py
+++ b/scooby/__init__.py
@@ -1,7 +1,8 @@
+# coding=utf-8
+
 # These are our default optional packages to investigate
 SCOOBY_PACKAGES = ['numpy', 'scipy', 'IPython', 'matplotlib']
 
-# coding=utf-8
 from scooby.extras import MKL_INFO, TOTAL_RAM
 from scooby.knowledge import VERSION_ATTRIBUTES
 from scooby.mysteries import in_ipython, in_ipykernel

--- a/scooby/__init__.py
+++ b/scooby/__init__.py
@@ -3,7 +3,7 @@
 # These are our default optional packages to investigate
 SCOOBY_PACKAGES = ['numpy', 'scipy', 'IPython', 'matplotlib']
 
-from scooby.extras import MKL_INFO, TOTAL_RAM
+from scooby.extras import MKL_INFO, TOTAL_RAM, sort_dictionary
 from scooby.knowledge import VERSION_ATTRIBUTES
 from scooby.mysteries import in_ipython, in_ipykernel
 from scooby.report import Report

--- a/scooby/__init__.py
+++ b/scooby/__init__.py
@@ -1,5 +1,5 @@
 # These are our default optional packages to investigate
-SCOOBY_PACKAGES = ['numpy', 'scipy', 'IPython', 'matplotlib', 'scooby']
+SCOOBY_PACKAGES = ['numpy', 'scipy', 'IPython', 'matplotlib']
 
 # coding=utf-8
 from scooby.extras import MKL_INFO, TOTAL_RAM

--- a/scooby/__init__.py
+++ b/scooby/__init__.py
@@ -12,7 +12,7 @@ from scooby.report import Report
 def investigate(core=None,
                 optional=SCOOBY_PACKAGES,
                 additional=None,
-                ncol=3, text_width=54):
+                ncol=3, text_width=54, sort=False):
     """
     Have Scooby investigate the active Python environment. This returns a
     :class:`scooby.Report` object which displays the system information
@@ -37,9 +37,12 @@ def investigate(core=None,
     text_width : int, optional
         The text width for non-HTML display modes
 
+    sort : bool, optional
+        Sort the packages when the report is shown
+
     """
     versions = Report(core=core, optional=optional, additional=additional,
-                        ncol=ncol, text_width=text_width)
+                        ncol=ncol, text_width=text_width, sort=sort)
     return versions
 
 

--- a/scooby/extras.py
+++ b/scooby/extras.py
@@ -25,3 +25,11 @@ elif numexpr:
     MKL_INFO = numexpr.get_vml_version()
 else:
     MKL_INFO = False
+
+
+def sort_dictionary(dictionary):
+    """Sorts a dictionary alphabetically. Case insensitive."""
+    sorted_dictionary = {}
+    for name in sorted(dictionary.keys(), key=lambda x: x.lower()):
+        sorted_dictionary[name] = dictionary[name]
+    return sorted_dictionary

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -91,6 +91,9 @@ class PythonInfo:
         optional = safety(optional)
         additional = safety(additional)
 
+        # Always show scooby as the very last package reported
+        additional.append('scooby')
+
         # First listed packages
         self.add_packages(core)
         # Optional packages to appear after the core

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -78,7 +78,6 @@ class PythonInfo:
                        additional=None):
         self._packages = {} # Holds name of packages and their version
         self._failures = {} # Holds failures and reason
-        self._packages['scooby'] = scooby.__version__
 
         # Make sure arguments are good
         def safety(x):

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -77,6 +77,7 @@ class PythonInfo:
                        additional=None):
         self._packages = {} # Holds name of packages and their version
         self._failures = {} # Holds failures and reason
+        self._packages['scooby'] = scooby.__version__
 
         # Make sure arguments are good
         def safety(x):
@@ -250,9 +251,6 @@ class Report(PlatformInfo, PythonInfo):
 
         # Width for text-version
         text = '\n' + self.text_width*'-' + '\n'
-
-        text += "  Looks like we've got another mystery on our hands!\n"
-        text += "  Scooby {} reporting for duty!\n".format(scooby.__version__)
 
         # Date and time info as title
         date_text = '  Date: '

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -7,6 +7,7 @@ import textwrap
 import time
 from types import ModuleType
 
+import scooby
 from scooby.extras import MKL_INFO, TOTAL_RAM
 from scooby.knowledge import VERSION_ATTRIBUTES
 from scooby.mysteries import in_ipython, in_ipykernel
@@ -249,6 +250,9 @@ class Report(PlatformInfo, PythonInfo):
 
         # Width for text-version
         text = '\n' + self.text_width*'-' + '\n'
+
+        text += "  Looks like we've got another mystery on our hands!\n"
+        text += "  Scooby {} reporting for duty!\n".format(scooby.__version__)
 
         # Date and time info as title
         date_text = '  Date: '

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -8,6 +8,7 @@ import time
 from types import ModuleType
 
 import scooby
+from scooby import SCOOBY_PACKAGES
 from scooby.extras import MKL_INFO, TOTAL_RAM
 from scooby.knowledge import VERSION_ATTRIBUTES
 from scooby.mysteries import in_ipython, in_ipykernel
@@ -72,8 +73,8 @@ class PythonInfo:
     """An internal helper class to handle managing Python infromation and
     package versions"""
 
-    def __init__(self, core=('numpy', 'scipy',),
-                       optional=('IPython', 'matplotlib',),
+    def __init__(self, core=None,
+                       optional=SCOOBY_PACKAGES,
                        additional=None):
         self._packages = {} # Holds name of packages and their version
         self._failures = {} # Holds failures and reason
@@ -237,7 +238,7 @@ class Report(PlatformInfo, PythonInfo):
 
     """
     def __init__(self, core=None,
-                       optional=('numpy', 'scipy', 'IPython', 'matplotlib',),
+                       optional=SCOOBY_PACKAGES,
                        additional=None,
                        ncol=3, text_width=80):
         PythonInfo.__init__(self, core=core, optional=optional,

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -9,9 +9,9 @@ from types import ModuleType
 
 import scooby
 from scooby import SCOOBY_PACKAGES
-from scooby.extras import MKL_INFO, TOTAL_RAM
+from scooby.extras import MKL_INFO, TOTAL_RAM, sort_dictionary
 from scooby.knowledge import get_from_knowledge_base
-from scooby.mysteries import in_ipython, in_ipykernel
+from scooby.mysteries import in_ipykernel, in_ipython
 
 UNAVAILABLE_MSG = 'unavailable'
 VERSION_UNKNOWN_MSG = 'unknown'
@@ -75,9 +75,10 @@ class PythonInfo:
 
     def __init__(self, core=None,
                        optional=SCOOBY_PACKAGES,
-                       additional=None):
+                       additional=None, sort=False):
         self._packages = {} # Holds name of packages and their version
         self._failures = {} # Holds failures and reason
+        self._sort = sort
 
         # Make sure arguments are good
         def safety(x):
@@ -193,6 +194,8 @@ class PythonInfo:
         """Return versions of all packages (available and unavailable/unknown)"""
         packages = dict(self._packages)
         packages.update(self._failures)
+        if self._sort:
+            packages = sort_dictionary(packages)
         return packages
 
 
@@ -242,9 +245,9 @@ class Report(PlatformInfo, PythonInfo):
     def __init__(self, core=None,
                        optional=SCOOBY_PACKAGES,
                        additional=None,
-                       ncol=3, text_width=80):
+                       ncol=3, text_width=80, sort=False,):
         PythonInfo.__init__(self, core=core, optional=optional,
-                            additional=additional)
+                            additional=additional, sort=sort)
         self.ncol = int(ncol)
         self.text_width = int(text_width)
 
@@ -292,7 +295,11 @@ class Report(PlatformInfo, PythonInfo):
         text += '\n'
 
         # Loop over packages
-        for name, version in self._packages.items():
+        if self._sort:
+            packages = sort_dictionary(self._packages)
+        else:
+            packages = self._packages
+        for name, version in packages.items():
             text += '{:>15} : {}\n'.format(version, name)
 
         # Show failures:
@@ -302,7 +309,11 @@ class Report(PlatformInfo, PythonInfo):
                 text += '  '+txt+'\n'
             # Loop over failed packages
             text += '\n'
-            for name, result in self._failures.items():
+            if self._sort:
+                packages = sort_dictionary(self._failures)
+            else:
+                packages = self._failures
+            for name, result in packages.items():
                 text += '{:>15} : {}\n'.format(result, name)
 
         ############ MKL details ############


### PR DESCRIPTION
Resolve #14 

Always puts `scooby` last and allows users to sort packages alphabetically if desired.