### PR TITLE
Using UTF-8 for reading long description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 __version__ = '0.4.1'
 
-with open("README.md", "r") as f:
+with open("README.md", "r", encoding="utf-8") as f:
     long_description = f.read()
 
 setuptools.setup(


### PR DESCRIPTION
Installing fails in CentOS Python3.6