### PR TITLE
Add import patcher to track all imported packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ sudo: false
 
 install:
   - python -m pip install -r requirements.txt
-  - python -m pip install numpy scipy no_version pytest bs4
+  - python -m pip install numpy scipy no_version pytest bs4 pytest-cov
 
 script:
   - python -c "import scooby; print(scooby.Report(core='numpy'))"
@@ -23,7 +23,7 @@ script:
   # Test sorting
   - python -c "import scooby; print(scooby.Report(additional=['collections', 'foo', 'aaa'], sort=True))"
   # Test more complicated routines
-  - python -m pytest -v .
+  - python -m pytest -v --cov .
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ tracked and Scooby can report their versions.
 Once you are ready to generate a report, instantiate a `TrackedReport` object.
 
 In the following example, we import a constant from `scipy` which will report
-the versions of `scipy` and `numpy` both packages are loaded in the session
+the versions of `scipy` and `numpy` as both packages are loaded in the session
 (note that `numpy` is internally loaded by `scipy`).
 
 ```py

--- a/README.md
+++ b/README.md
@@ -212,6 +212,50 @@ as well. A few examples:
 ```
 Again, modules can be provided as already loaded ones or as string.
 
+
+### Tracking Imports in a Session
+
+Scooby has the ability to track all imported modules during a Python session
+such that *any* imported, non-standard lib package that is used in the session
+is reported by a `TrackedReport`. For instance, start a session by importing
+Scooby and enabling tracking with the `track_imports()` function.
+Then *all* subsequent packages that are imported during the session will be
+tracked and Scooby can report their versions.
+Once you are ready to generate a report, instantiate a `TrackedReport` object.
+
+In the following example, we import a constant from `scipy` which will report
+the versions of `scipy` and `numpy` both packages are loaded in the session
+(note that `numpy` is internally loaded by `scipy`).
+
+```py
+>>> import scooby
+>>> scooby.track_imports()
+
+>>> from scipy.constants import mu_0 # a float value
+
+>>> scooby.TrackedReport()
+```
+```
+--------------------------------------------------------------------------------
+  Date: Mon Dec 23 16:24:32 2019 EST
+
+            Darwin : OS
+                12 : CPU(s)
+            x86_64 : Machine
+             64bit : Architecture
+           32.0 GB : RAM
+            Python : Environment
+
+  Python 3.7.3 | packaged by conda-forge | (default, Dec  6 2019, 08:36:57)
+  [Clang 9.0.0 (tags/RELEASE_900/final)]
+
+             0.4.3 : scooby
+            1.17.3 : numpy
+             1.3.2 : scipy
+--------------------------------------------------------------------------------
+```
+
+
 ## Optional Requirements
 
 The following is a list of optional requirements and their purpose:

--- a/scooby/__init__.py
+++ b/scooby/__init__.py
@@ -15,11 +15,12 @@ Werthmüller for ``empymod``, ``emg3d``, and the ``SimPEG`` framework
 ``watermark.py`` from https://github.com/rasbt/watermark.
 """
 
-from scooby.report import Inspection, Report, get_version
+from scooby.report import Report, get_version
 from scooby.knowledge import get_standard_lib_modules, in_ipython, in_ipykernel
+from scooby.tracker import TrackedReport, track_imports, untrack_imports
 
-__all__ = ['Inspection', 'Report', 'get_standard_lib_modules', 'in_ipython',
-           'in_ipykernel', 'get_version']
+__all__ = ['Report', 'TrackedReport', 'get_standard_lib_modules', 'in_ipython',
+           'in_ipykernel', 'get_version', 'track_imports', 'untrack_imports']
 
 
 __author__ = 'Dieter Werthmüller & Bane Sullivan'

--- a/scooby/__init__.py
+++ b/scooby/__init__.py
@@ -15,10 +15,11 @@ Werthmüller for ``empymod``, ``emg3d``, and the ``SimPEG`` framework
 ``watermark.py`` from https://github.com/rasbt/watermark.
 """
 
-from scooby.report import Report, get_version
-from scooby.knowledge import in_ipython, in_ipykernel
+from scooby.report import Inspection, Report, get_version
+from scooby.knowledge import get_standard_lib_modules, in_ipython, in_ipykernel
 
-__all__ = ['Report', 'in_ipython', 'in_ipykernel', 'get_version']
+__all__ = ['Inspection', 'Report', 'get_standard_lib_modules', 'in_ipython',
+           'in_ipykernel', 'get_version']
 
 
 __author__ = 'Dieter Werthmüller & Bane Sullivan'

--- a/scooby/knowledge.py
+++ b/scooby/knowledge.py
@@ -113,5 +113,7 @@ def get_standard_lib_modules():
         "__builtin__",
         "__builtins__",
         "builtins",
+        "session",
+        "math",
         }.union(stdlib_pkgs)
     return stdlib_pkgs

--- a/scooby/knowledge.py
+++ b/scooby/knowledge.py
@@ -12,7 +12,8 @@ It also checks and stores mandatory additional information, if possible, such
 as available RAM or MKL info.
 
 """
-
+import distutils.sysconfig as sysconfig
+import os
 
 try:
     import psutil
@@ -100,3 +101,17 @@ def in_ipykernel():
         except NameError:
             pass
     return ipykernel
+
+
+def get_standard_lib_modules():
+    """Returns a set of the names of all modules in the standard library"""
+    names = os.listdir(sysconfig.get_python_lib(standard_lib=True))
+    stdlib_pkgs = set([name if not name.endswith(".py") else name[:-3] for name in names])
+    stdlib_pkgs = {
+        "python",
+        "sys",
+        "__builtin__",
+        "__builtins__",
+        "builtins",
+        }.union(stdlib_pkgs)
+    return stdlib_pkgs

--- a/scooby/knowledge.py
+++ b/scooby/knowledge.py
@@ -50,6 +50,7 @@ VERSION_ATTRIBUTES = {
     'vtk': 'VTK_VERSION',
     'vtkmodules.all': 'VTK_VERSION',
     'PyQt5': 'Qt.PYQT_VERSION_STR',
+    'sip': 'SIP_VERSION_STR',
 }
 
 
@@ -115,5 +116,15 @@ def get_standard_lib_modules():
         "builtins",
         "session",
         "math",
+        "itertools",
+        "binascii",
+        "array",
+        "atexit",
+        "fcntl",
+        "errno",
+        "gc",
+        "time",
+        "unicodedata",
+
         }.union(stdlib_pkgs)
     return stdlib_pkgs

--- a/scooby/knowledge.py
+++ b/scooby/knowledge.py
@@ -125,6 +125,6 @@ def get_standard_lib_modules():
         "gc",
         "time",
         "unicodedata",
-
+        "mmap",
         }.union(stdlib_pkgs)
     return stdlib_pkgs

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -14,7 +14,6 @@ import platform
 import sys
 import textwrap
 import time
-from copy import copy
 from types import ModuleType
 
 from .knowledge import (MKL_INFO, TOTAL_RAM, VERSION_ATTRIBUTES,
@@ -308,13 +307,12 @@ class Inspection(Report):
 
         stdlib_pkgs = get_standard_lib_modules()
         modules = set()
-        for var in copy(global_vars).values():
-            if hasattr(var, "__module__") and var.__module__ != "__main__":
-                var = sys.modules[var.__module__]
-            if inspect.ismodule(var):
-                name = var.__name__.split(".")[0]
-                if name not in stdlib_pkgs:
-                    modules.add(name)
+        modules_dirty = set([val if inspect.ismodule(val) else (sys.modules[val.__module__] if (hasattr(val, "__module__") and val.__module__ != "__main__") else None) for val in global_vars.values()])
+        modules_dirty.remove(None)
+        for module in modules_dirty:
+            name = module.__name__.split(".")[0]
+            if name not in stdlib_pkgs:
+                modules.add(name)
 
         Report.__init__(self, additional=additional, core=modules, ncol=ncol,
                         text_width=text_width, sort=sort, optional=[])

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -307,7 +307,11 @@ class Inspection(Report):
 
         stdlib_pkgs = get_standard_lib_modules()
         modules = set()
-        modules_dirty = set([val if inspect.ismodule(val) else (sys.modules[val.__module__] if (hasattr(val, "__module__") and val.__module__ != "__main__") else None) for val in global_vars.values()])
+        modules_dirty = set(
+            [val if inspect.ismodule(val) else (sys.modules[val.__module__] if
+             (hasattr(val, "__module__") and val.__module__ != "__main__") else
+             None) for val in global_vars.values()]
+        )
         modules_dirty.remove(None)
         for module in modules_dirty:
             name = module.__name__.split(".")[0]

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -8,7 +8,6 @@ The main routine containing the `Report` class.
 """
 
 import importlib
-import inspect
 import multiprocessing
 import platform
 import sys
@@ -17,8 +16,7 @@ import time
 from types import ModuleType
 
 from .knowledge import (MKL_INFO, TOTAL_RAM, VERSION_ATTRIBUTES,
-                        VERSION_METHODS, get_standard_lib_modules,
-                        in_ipykernel, in_ipython)
+                        VERSION_METHODS, in_ipykernel, in_ipython)
 
 MODULE_NOT_FOUND = 'Could not import'
 VERSION_NOT_FOUND = 'Version unknown'
@@ -297,29 +295,6 @@ class Report(PlatformInfo, PythonInfo):
 
         return html
 
-
-class Inspection(Report):
-    """A class to inspect the active environment and generate a report based
-    on all imported modules. Simply pass the ``globals()`` dictionary.
-    """
-    def __init__(self, global_vars, additional=None, ncol=3, text_width=80,
-                 sort=False,):
-
-        stdlib_pkgs = get_standard_lib_modules()
-        modules = set()
-        modules_dirty = set(
-            [val if inspect.ismodule(val) else (sys.modules[val.__module__] if
-             (hasattr(val, "__module__") and val.__module__ != "__main__") else
-             None) for val in global_vars.values()]
-        )
-        modules_dirty.remove(None)
-        for module in modules_dirty:
-            name = module.__name__.split(".")[0]
-            if name not in stdlib_pkgs:
-                modules.add(name)
-
-        Report.__init__(self, additional=additional, core=modules, ncol=ncol,
-                        text_width=text_width, sort=sort, optional=[])
 
 
 # This functionaliy might also be of interest on its own.

--- a/scooby/tracker.py
+++ b/scooby/tracker.py
@@ -9,14 +9,30 @@ CLASSIC_IMPORT = builtins.__import__
 # The variable we track all imports in
 TRACKED_IMPORTS = []
 
+MODULES_TO_IGNORE = {
+    "pyMKL",
+    "mkl",
+    "numexpr",
+    "vtkmodules",
+    "mpl_toolkits",
+}
+
 
 STDLIB_PKGS = get_standard_lib_modules()
+
+
+def _criterion(name):
+    if (len(name) > 0 and name not in STDLIB_PKGS and not name.startswith("_")
+        and name not in MODULES_TO_IGNORE):
+        return True
+    return False
+
 
 def scooby_import(name, globals=None, locals=None, fromlist=(), level=0):
     """A custom override of the import method to track package names"""
     m = CLASSIC_IMPORT(name, globals=globals, locals=locals, fromlist=fromlist, level=level)
     name = name.split(".")[0]
-    if level == 0 and len(name) > 0 and name not in STDLIB_PKGS:
+    if level == 0 and _criterion(name):
         TRACKED_IMPORTS.append(name)
     return m
 

--- a/scooby/tracker.py
+++ b/scooby/tracker.py
@@ -1,0 +1,51 @@
+import builtins
+
+from scooby.report import Report
+from scooby.knowledge import get_standard_lib_modules
+
+
+CLASSIC_IMPORT = builtins.__import__
+
+# The variable we track all imports in
+TRACKED_IMPORTS = []
+
+
+STDLIB_PKGS = get_standard_lib_modules()
+
+def scooby_import(name, globals=None, locals=None, fromlist=(), level=0):
+    """A custom override of the import method to track package names"""
+    m = CLASSIC_IMPORT(name, globals=globals, locals=locals, fromlist=fromlist, level=level)
+    name = name.split(".")[0]
+    if level == 0 and len(name) > 0 and name not in STDLIB_PKGS:
+        TRACKED_IMPORTS.append(name)
+    return m
+
+
+def track_imports():
+    """Track all imported modules for the remainder of this session."""
+    builtins.__import__ = scooby_import
+    return
+
+
+def untrack_imports():
+    """Stop tracking imports and return to the builtin import method. This will
+    also clear the tracked imports"""
+    builtins.__import__ = CLASSIC_IMPORT
+    TRACKED_IMPORTS.clear()
+    return
+
+
+
+class TrackedReport(Report):
+    """A class to inspect the active environment and generate a report based
+    on all imported modules. Simply pass the ``globals()`` dictionary.
+    """
+    def __init__(self, additional=None, ncol=3, text_width=80, sort=False):
+        if len(TRACKED_IMPORTS) < 1:
+            raise RuntimeError("There are no tracked imports, please use "
+                               "`scooby.track_imports()` before running your "
+                               "code.")
+
+        Report.__init__(self, additional=additional, core=TRACKED_IMPORTS,
+                        ncol=ncol, text_width=text_width, sort=sort,
+                        optional=[])

--- a/scooby/tracker.py
+++ b/scooby/tracker.py
@@ -69,7 +69,7 @@ class TrackedReport(Report):
     def __init__(self, additional=None, ncol=3, text_width=80, sort=False):
         if not TRACKING_SUPPORTED:
             raise RuntimeError(SUPPORT_MESSAGE)
-        if len(TRACKED_IMPORTS) < 1:
+        if len(TRACKED_IMPORTS) < 2:
             raise RuntimeError("There are no tracked imports, please use "
                                "`scooby.track_imports()` before running your "
                                "code.")

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -3,6 +3,7 @@ import mock
 import numpy
 import pytest
 import re
+import sys
 
 import scooby
 
@@ -94,6 +95,7 @@ def test_extra_meta():
         report = scooby.Report(extra_meta="fo")
 
 
+@pytest.mark.skipif(sys.version_info.major < 3, reason="Tracking not supported on Python 2.")
 def test_tracking():
     scooby.track_imports()
     from scipy.constants import mu_0 # a float value

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -92,3 +92,16 @@ def test_extra_meta():
         report = scooby.Report(extra_meta="foo")
     with pytest.raises(TypeError):
         report = scooby.Report(extra_meta="fo")
+
+
+def test_tracking():
+    scooby.track_imports()
+    from scipy.constants import mu_0 # a float value
+    report = scooby.TrackedReport()
+    scooby.untrack_imports()
+    import no_version
+    assert "numpy" in report.packages
+    assert "scipy" in report.packages
+    assert "no_version" not in report.packages
+    assert "pytest" not in report.packages
+    assert "mu_0" not in report.packages


### PR DESCRIPTION
Here is a neat way to easily generate a report at the end of a notebook that has imported many packages without having to list all the packages when creating a report:

- Everything is tracked except libraries you may have only fetched primitive types from (e.g. a float from `scipy.constants`)

```py
# aliased imports where we want the full package name
import numpy as np
import matplotlib.pyplot as plt
import pyvista as pv
import pandas as pd

# Many imports from a single package to track
from SimPEG import (
    Mesh, Maps, Utils, DataMisfit, Regularization,
    Optimization, Inversion, InvProblem, Directives
)
import SimPEG.EM as EM

# some standard libs that we don't want in the report
import inspect
import sys
import os

# import functions/classes from packages we need to track
from pymatsolver import PardisoSolver

# Note that this will not work for primitive types imported
#  scipy is not included in the report which could be an issue
from scipy.constants import mu_0 # a float value

# random function/class we don't care about
def foo():
    pass

class goo():
    pass

import scooby
scooby.Inspection(globals(), sort=True)
```

<img width="702" alt="Screen Shot 2019-11-11 at 10 22 23 PM" src="https://user-images.githubusercontent.com/22067021/68644284-bfc11700-04d1-11ea-8637-361cbc5f5827.png">


*`jupyterthemes` is an extra in there because my Jupyter kernels load that at start up*