### PR TITLE
Add extra meta info pairs

### DIFF
--- a/scooby/report.py
+++ b/scooby/report.py
@@ -156,9 +156,12 @@ class Report(PlatformInfo, PythonInfo):
     sort : bool, optional
         Sort the packages when the report is shown
 
+    extra_meta : tuple(str, str)
+        Additional two component pairs of meta information to display
+
     """
     def __init__(self, additional=None, core=None, optional=None, ncol=3,
-                 text_width=80, sort=False,):
+                 text_width=80, sort=False, extra_meta=None,):
 
         # Set default optional packages to investigate
         if optional is None:
@@ -168,6 +171,19 @@ class Report(PlatformInfo, PythonInfo):
                             optional=optional, sort=sort)
         self.ncol = int(ncol)
         self.text_width = int(text_width)
+
+        if extra_meta is not None:
+            if not isinstance(extra_meta, (list, tuple)):
+                raise TypeError("`extra_meta` must be a list/tuple of key-value pairs.")
+            if len(extra_meta) == 2 and isinstance(extra_meta[0], str):
+                extra_meta = [extra_meta]
+            for meta in extra_meta:
+                if not isinstance(meta, (list, tuple)) or len(meta) != 2:
+                    raise TypeError("Each chunk of meta info must have two values.")
+        else:
+            extra_meta = []
+        self._extra_meta = extra_meta
+
 
     def __repr__(self):
         """Plain-text version information."""
@@ -189,6 +205,8 @@ class Report(PlatformInfo, PythonInfo):
         text += '{:>18}'.format(self.cpu_count)+' : CPU(s)\n'
         text += '{:>18}'.format(self.machine)+' : Machine\n'
         text += '{:>18}'.format(self.architecture)+' : Architecture\n'
+        for meta in self._extra_meta:
+            text += '{:>18}'.format(meta[0])+' : {}\n'.format(meta[1])
         if TOTAL_RAM:
             text += '{:>18}'.format(self.total_ram)+' : RAM\n'
         text += '{:>18}'.format(self.python_environment)+' : Environment\n'
@@ -263,6 +281,8 @@ class Report(PlatformInfo, PythonInfo):
         html, i = cols(html, self.cpu_count, 'CPU(s)', self.ncol, i)
         html, i = cols(html, self.machine, 'Machine', self.ncol, i)
         html, i = cols(html, self.architecture, 'Architecture', self.ncol, i)
+        for meta in self._extra_meta:
+            html, i = cols(html, meta[1], meta[0], self.ncol, i)
         if TOTAL_RAM:
             html, i = cols(html, self.total_ram, 'RAM', self.ncol, i)
         html, i = cols(

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -205,11 +205,11 @@ class Report(PlatformInfo, PythonInfo):
         text += '{:>18}'.format(self.cpu_count)+' : CPU(s)\n'
         text += '{:>18}'.format(self.machine)+' : Machine\n'
         text += '{:>18}'.format(self.architecture)+' : Architecture\n'
-        for meta in self._extra_meta:
-            text += '{:>18}'.format(meta[0])+' : {}\n'.format(meta[1])
         if TOTAL_RAM:
             text += '{:>18}'.format(self.total_ram)+' : RAM\n'
         text += '{:>18}'.format(self.python_environment)+' : Environment\n'
+        for meta in self._extra_meta:
+            text += '{:>18}'.format(meta[0])+' : {}\n'.format(meta[1])
 
         # ########## Python details ############
         text += '\n'
@@ -281,12 +281,12 @@ class Report(PlatformInfo, PythonInfo):
         html, i = cols(html, self.cpu_count, 'CPU(s)', self.ncol, i)
         html, i = cols(html, self.machine, 'Machine', self.ncol, i)
         html, i = cols(html, self.architecture, 'Architecture', self.ncol, i)
-        for meta in self._extra_meta:
-            html, i = cols(html, meta[1], meta[0], self.ncol, i)
         if TOTAL_RAM:
             html, i = cols(html, self.total_ram, 'RAM', self.ncol, i)
         html, i = cols(
                 html, self.python_environment, 'Environment', self.ncol, i)
+        for meta in self._extra_meta:
+            html, i = cols(html, meta[1], meta[0], self.ncol, i)
         # Finish row
         html += "  </tr>\n"
 

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -209,7 +209,7 @@ class Report(PlatformInfo, PythonInfo):
             text += '{:>18}'.format(self.total_ram)+' : RAM\n'
         text += '{:>18}'.format(self.python_environment)+' : Environment\n'
         for meta in self._extra_meta:
-            text += '{:>18}'.format(meta[0])+' : {}\n'.format(meta[1])
+            text += '{:>18}'.format(meta[1])+' : {}\n'.format(meta[0])
 
         # ########## Python details ############
         text += '\n'

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -80,12 +80,12 @@ def test_plain_vs_html():
 
 def test_extra_meta():
     report = scooby.Report(extra_meta=("key", "value"))
-    assert "key : value" in report.__repr__()
+    assert "value : key" in report.__repr__()
     report = scooby.Report(extra_meta=(("key", "value"),))
-    assert "key : value" in report.__repr__()
+    assert "value : key" in report.__repr__()
     report = scooby.Report(extra_meta=(("key", "value"), ("another", "one")))
-    assert "key : value" in report.__repr__()
-    assert "another : one" in report.__repr__()
+    assert "value : key" in report.__repr__()
+    assert "one : another" in report.__repr__()
     with pytest.raises(TypeError):
         report = scooby.Report(extra_meta=(("key", "value"), "foo"))
     with pytest.raises(TypeError):

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -75,3 +75,20 @@ def test_plain_vs_html():
     # Plain text currently starts with `Date :`;
     # we should remove that, or add it to the html version too.
     assert text_html == text_plain[5:]
+
+
+
+def test_extra_meta():
+    report = scooby.Report(extra_meta=("key", "value"))
+    assert "key : value" in report.__repr__()
+    report = scooby.Report(extra_meta=(("key", "value"),))
+    assert "key : value" in report.__repr__()
+    report = scooby.Report(extra_meta=(("key", "value"), ("another", "one")))
+    assert "key : value" in report.__repr__()
+    assert "another : one" in report.__repr__()
+    with pytest.raises(TypeError):
+        report = scooby.Report(extra_meta=(("key", "value"), "foo"))
+    with pytest.raises(TypeError):
+        report = scooby.Report(extra_meta="foo")
+    with pytest.raises(TypeError):
+        report = scooby.Report(extra_meta="fo")


### PR DESCRIPTION
This adds an option for users/downstream projects to add extra meta information in the header. For example, check out https://github.com/pyvista/pyvista/pull/512