### PR TITLE
Add to_dict() for serialization

### DIFF
--- a/scooby/__init__.py
+++ b/scooby/__init__.py
@@ -16,7 +16,7 @@ Werthmüller for ``empymod``, ``emg3d``, and the ``SimPEG`` framework
 """
 
 from scooby.report import Report, get_version
-from scooby.knowledge import (get_standard_lib_modules, in_ipykernel,
+from scooby.knowledge import (get_standard_lib_modules, in_ipykernel,  # noqa
                               in_ipython, meets_version, version_tuple)
 from scooby.tracker import TrackedReport, track_imports, untrack_imports
 

--- a/scooby/knowledge.py
+++ b/scooby/knowledge.py
@@ -107,7 +107,8 @@ def in_ipykernel():
 def get_standard_lib_modules():
     """Returns a set of the names of all modules in the standard library"""
     names = os.listdir(sysconfig.get_python_lib(standard_lib=True))
-    stdlib_pkgs = set([name if not name.endswith(".py") else name[:-3] for name in names])
+    stdlib_pkgs = set([name if not name.endswith(".py") else name[:-3]
+                       for name in names])
     stdlib_pkgs = {
         "python",
         "sys",
@@ -144,8 +145,8 @@ def version_tuple(v):
         split_v.append('0')
 
     if len(split_v) > 3:
-        raise ValueError('Version strings containing more than three parts cannot '
-                         'be parsed')
+        raise ValueError('Version strings containing more than three parts '
+                         'cannot be parsed')
 
     return tuple(map(int, split_v))
 

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -174,12 +174,14 @@ class Report(PlatformInfo, PythonInfo):
 
         if extra_meta is not None:
             if not isinstance(extra_meta, (list, tuple)):
-                raise TypeError("`extra_meta` must be a list/tuple of key-value pairs.")
+                raise TypeError("`extra_meta` must be a list/tuple of "
+                                "key-value pairs.")
             if len(extra_meta) == 2 and isinstance(extra_meta[0], str):
                 extra_meta = [extra_meta]
             for meta in extra_meta:
                 if not isinstance(meta, (list, tuple)) or len(meta) != 2:
-                    raise TypeError("Each chunk of meta info must have two values.")
+                    raise TypeError(
+                            "Each chunk of meta info must have two values.")
         else:
             extra_meta = []
         self._extra_meta = extra_meta
@@ -323,7 +325,7 @@ class Report(PlatformInfo, PythonInfo):
 
         # Platform/OS details
         out['OS'] = self.system
-        out['CPU(s)'] = self.cpu_count
+        out['CPU(s)'] = str(self.cpu_count)
         out['Machine'] = self.machine
         out['Architecture'] = self.architecture
         if TOTAL_RAM:

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -184,7 +184,6 @@ class Report(PlatformInfo, PythonInfo):
             extra_meta = []
         self._extra_meta = extra_meta
 
-
     def __repr__(self):
         """Plain-text version information."""
 
@@ -272,8 +271,7 @@ class Report(PlatformInfo, PythonInfo):
         html = "<table style='border: 3px solid #ddd;'>\n"
 
         # Date and time info as title
-        html = colspan(html, self.date,
-                       self.ncol, 0)
+        html = colspan(html, self.date, self.ncol, 0)
 
         # ########## Platform/OS details ############
         html += "  <tr>\n"
@@ -315,6 +313,37 @@ class Report(PlatformInfo, PythonInfo):
 
         return html
 
+    def to_dict(self):
+        """Return report as dict for storage."""
+
+        out = {}
+
+        # Date and time info
+        out['Date'] = self.date
+
+        # Platform/OS details
+        out['OS'] = self.system
+        out['CPU(s)'] = self.cpu_count
+        out['Machine'] = self.machine
+        out['Architecture'] = self.architecture
+        if TOTAL_RAM:
+            out['RAM'] = self.total_ram
+        out['Environment'] = self.python_environment
+        for meta in self._extra_meta:
+            out[meta[1]] = meta[0]
+
+        # Python details
+        out['Python'] = self.sys_version
+
+        # Loop over packages
+        for name, version in self._packages.items():
+            out[name] = version
+
+        # MKL details
+        if MKL_INFO:
+            out['MKL'] = MKL_INFO
+
+        return out
 
 
 # This functionaliy might also be of interest on its own.

--- a/scooby/tracker.py
+++ b/scooby/tracker.py
@@ -2,7 +2,8 @@ from scooby.report import Report
 from scooby.knowledge import get_standard_lib_modules
 
 TRACKING_SUPPORTED = False
-SUPPORT_MESSAGE = "Tracking is not supported for this version of Python. Try using a modern version of Python."
+SUPPORT_MESSAGE = ("Tracking is not supported for this version of Python. "
+                   "Try using a modern version of Python.")
 try:
     import builtins
     CLASSIC_IMPORT = builtins.__import__
@@ -26,7 +27,7 @@ STDLIB_PKGS = get_standard_lib_modules()
 
 def _criterion(name):
     if (len(name) > 0 and name not in STDLIB_PKGS and not name.startswith("_")
-        and name not in MODULES_TO_IGNORE):
+            and name not in MODULES_TO_IGNORE):
         return True
     return False
 
@@ -34,7 +35,8 @@ def _criterion(name):
 if TRACKING_SUPPORTED:
     def scooby_import(name, globals=None, locals=None, fromlist=(), level=0):
         """A custom override of the import method to track package names"""
-        m = CLASSIC_IMPORT(name, globals=globals, locals=locals, fromlist=fromlist, level=level)
+        m = CLASSIC_IMPORT(name, globals=globals, locals=locals,
+                           fromlist=fromlist, level=level)
         name = name.split(".")[0]
         if level == 0 and _criterion(name):
             TRACKED_IMPORTS.append(name)
@@ -58,7 +60,6 @@ def untrack_imports():
     TRACKED_IMPORTS.clear()
     TRACKED_IMPORTS.append("scooby")
     return
-
 
 
 class TrackedReport(Report):

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -7,6 +7,7 @@ import sys
 
 import scooby
 
+
 def test_report():
     report = scooby.Report()
     text = str(report)
@@ -21,10 +22,18 @@ def test_report():
     assert len(html) > 0
     # Same as what is printed in Travis build log
     report = scooby.Report(additional=['mock', 'foo'])
-    report = scooby.Report(additional=['foo',])
-    report = scooby.Report(additional=[mock,])
+    report = scooby.Report(additional=['foo', ])
+    report = scooby.Report(additional=[mock, ])
     report = scooby.Report(additional=mock)
     report = scooby.Report(additional=['collections', 'foo', 'aaa'], sort=True)
+
+
+def test_dict():
+    report = scooby.Report(['no_version', 'does_not_exist'])
+    for key, value in report.to_dict().items():
+        if key is not 'MKL':
+            assert key in report.__repr__()
+        assert value[:10] in report.__repr__()
 
 
 def test_inheritence_example():
@@ -50,7 +59,7 @@ def test_inheritence_example():
 
 
 def test_ipy():
-    result = scooby.in_ipykernel()
+    scooby.in_ipykernel()
 
 
 def test_get_version():
@@ -78,7 +87,6 @@ def test_plain_vs_html():
     assert text_html == text_plain[5:]
 
 
-
 def test_extra_meta():
     report = scooby.Report(extra_meta=("key", "value"))
     assert "value : key" in report.__repr__()
@@ -95,13 +103,14 @@ def test_extra_meta():
         report = scooby.Report(extra_meta="fo")
 
 
-@pytest.mark.skipif(sys.version_info.major < 3, reason="Tracking not supported on Python 2.")
+@pytest.mark.skipif(sys.version_info.major < 3,
+                    reason="Tracking not supported on Python 2.")
 def test_tracking():
     scooby.track_imports()
-    from scipy.constants import mu_0 # a float value
+    from scipy.constants import mu_0  # noqa ; a float value
     report = scooby.TrackedReport()
     scooby.untrack_imports()
-    import no_version
+    import no_version  # noqa
     assert "numpy" in report.packages
     assert "scipy" in report.packages
     assert "no_version" not in report.packages


### PR DESCRIPTION
Add a `to_dict()` method to serialize the report. This can be useful to, e.g., attach meta-data to data written to a file.

```
In [1]: import scooby                                                                                 

In [2]: scooby.Report().to_dict()                                                                     
Out[2]: 
{'Date': 'Wed Mar 18 06:36:40 2020 CET',
 'OS': 'Linux',
 'CPU(s)': 4,
 'Machine': 'x86_64',
 'Architecture': '64bit',
 'RAM': '7.7 GB',
 'Environment': 'IPython',
 'Python': '3.7.6 (default, Jan  8 2020, 19:59:22) \n[GCC 7.3.0]',
 'numpy': '1.18.1',
 'scipy': '1.4.1',
 'IPython': '7.12.0',
 'matplotlib': '3.1.3',
 'scooby': '0.5.2',
 'MKL': 'Intel(R) Math Kernel Library Version 2020.0.0 Product Build 20191122 for Intel(R) 64 architecture applications'}
```