### PR TITLE
Check if `mkl` has attribute `get_version_string`

### DIFF
--- a/scooby/knowledge.py
+++ b/scooby/knowledge.py
@@ -22,7 +22,8 @@ except ImportError:
 
 try:
     import mkl
-except ImportError:
+    mkl.get_version_string()
+except (ImportError, AttributeError):
     mkl = False
 
 try:


### PR DESCRIPTION
It just happened on an installation of mine that import of a package which scooby failed, because of a 
```
AttributeError: module 'mkl' has no attribute 'get_version_string'
```
So it was able to import `mkl`, but `mkl` had no version info. This fix ensures that that won't make scooby fail.