### PR TITLE
Add non-numeric version checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,21 +290,20 @@ the versions of `scipy` and `numpy` as both packages are loaded in the session
 ```
 ```
 --------------------------------------------------------------------------------
-  Date: Mon Dec 23 16:24:32 2019 EST
+  Date: Thu Apr 16 15:33:11 2020 MDT
 
-            Darwin : OS
-                12 : CPU(s)
-            x86_64 : Machine
-             64bit : Architecture
-           32.0 GB : RAM
-            Python : Environment
+                OS : Linux
+            CPU(s) : 8
+           Machine : x86_64
+      Architecture : 64bit
+               RAM : 62.7 GB
+       Environment : IPython
 
-  Python 3.7.3 | packaged by conda-forge | (default, Dec  6 2019, 08:36:57)
-  [Clang 9.0.0 (tags/RELEASE_900/final)]
+  Python 3.7.7 (default, Mar 10 2020, 15:16:38)  [GCC 7.5.0]
 
-             0.4.3 : scooby
-            1.17.3 : numpy
-             1.3.2 : scipy
+            scooby : 0.5.2
+             numpy : 1.18.1
+             scipy : 1.4.1
 --------------------------------------------------------------------------------
 ```
 

--- a/scooby/knowledge.py
+++ b/scooby/knowledge.py
@@ -135,6 +135,9 @@ def get_standard_lib_modules():
 def version_tuple(v):
     """Convert a version string to a tuple containing ints.
 
+    Non-numeric version strings will be converted to 0.  For example:
+    ``'0.28.0dev0'`` will be converted to ``'0.28.0'``
+
     Returns
     -------
     ver_tuple : tuple
@@ -149,7 +152,14 @@ def version_tuple(v):
         raise ValueError('Version strings containing more than three parts '
                          'cannot be parsed')
 
-    return tuple(map(int, split_v))
+    vals = []
+    for item in split_v:
+        if item.isnumeric():
+            vals.append(int(item))
+        else:
+            vals.append(0)
+
+    return tuple(vals)
 
 
 def meets_version(version, meets):

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -138,5 +138,7 @@ def test_version_compare():
 
     assert not scooby.meets_version('0.25.2', '0.26')
 
+    assert scooby.meets_version('0.28.0dev0', '0.25.2')
+
     with pytest.raises(ValueError):
         scooby.meets_version('0.25.2.0', '0.26')


### PR DESCRIPTION
Ran into an issue whereby I couldn't compare a development version.  For example:
```python
assert scooby.meets_version('0.28.0dev0', '0.25.2')
```
This PR no automatically converts any non-numeric value to a `0` for the purpose of comparison.