### PR TITLE
Fix standard lib when frozen

### DIFF
--- a/scooby/knowledge.py
+++ b/scooby/knowledge.py
@@ -14,6 +14,7 @@ as available RAM or MKL info.
 """
 import distutils.sysconfig as sysconfig
 import os
+import sys
 
 try:
     import psutil
@@ -107,9 +108,25 @@ def in_ipykernel():
 
 def get_standard_lib_modules():
     """Returns a set of the names of all modules in the standard library"""
-    names = os.listdir(sysconfig.get_python_lib(standard_lib=True))
-    stdlib_pkgs = set([name if not name.endswith(".py") else name[:-3]
-                       for name in names])
+    if getattr(sys, 'frozen', False):  # within pyinstaller
+        lib_path = os.path.join(sysconfig.get_python_lib(standard_lib=True), '..')
+        if os.path.isdir(lib_path):
+            names = os.listdir(lib_path)
+        else:
+            names = []
+
+        stdlib_pkgs = []
+        for name in names:
+            if name.endswith(".py"):
+                stdlib_pkgs.append(name[:-3])
+        stdlib_pkgs = set(stdlib_pkgs)
+
+    else:
+        names = os.listdir(sysconfig.get_python_lib(standard_lib=True))
+
+        stdlib_pkgs = set([name if not name.endswith(".py") else name[:-3]
+                           for name in names])
+
     stdlib_pkgs = {
         "python",
         "sys",


### PR DESCRIPTION
When using `pyinstaller`, the standard library directory is different than the one `sysconfig` identifies.  This results in the failure to run `scooby.Report`.