### PR TITLE
Use length of longest package name for formatting

### DIFF
--- a/scooby/report.py
+++ b/scooby/report.py
@@ -217,9 +217,11 @@ class Report(PlatformInfo, PythonInfo):
             text += '  '+txt+'\n'
         text += '\n'
 
+        # Get length of longest package
+        name_width = max(18, len(max(self._packages.keys(), key=len)))
         # Loop over packages
-        for version, name in self._packages.items():
-            text += '{:>18} : {}\n'.format(version, name)
+        for name, version in self._packages.items():
+            text += f'{name:>{name_width}} : {version}\n'
 
         # ########## MKL details ############
         if MKL_INFO:

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -201,14 +201,17 @@ class Report(PlatformInfo, PythonInfo):
             mult = indent
         text += date_text+'\n'
 
+        # Get length of longest package: min of 18 and max of 40
+        row_width = min(40, max(18, len(max(self._packages.keys(), key=len))))
+
         # ########## Platform/OS details ############
         repr_dict = self.to_dict()
         for key in ['OS', 'CPU(s)', 'Machine', 'Architecture', 'RAM',
                     'Environment']:
             if key in repr_dict:
-                text += '{:>18} : {}\n'.format(key, repr_dict[key])
+                text += f'{key:>{row_width}} : {repr_dict[key]}\n'
         for meta in self._extra_meta:
-            text += '{:>18}'.format(meta[0])+' : {}\n'.format(meta[1])
+            text += f'{meta[0]:>row_width} : {meta[1]}\n'
 
         # ########## Python details ############
         text += '\n'
@@ -217,11 +220,9 @@ class Report(PlatformInfo, PythonInfo):
             text += '  '+txt+'\n'
         text += '\n'
 
-        # Get length of longest package
-        name_width = max(18, len(max(self._packages.keys(), key=len)))
         # Loop over packages
         for name, version in self._packages.items():
-            text += f'{name:>{name_width}} : {version}\n'
+            text += f'{name:>{row_width}} : {version}\n'
 
         # ########## MKL details ############
         if MKL_INFO:

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -211,7 +211,7 @@ class Report(PlatformInfo, PythonInfo):
             if key in repr_dict:
                 text += f'{key:>{row_width}} : {repr_dict[key]}\n'
         for meta in self._extra_meta:
-            text += f'{meta[0]:>row_width} : {meta[1]}\n'
+            text += f'{meta[0]:>{row_width}} : {meta[1]}\n'
 
         # ########## Python details ############
         text += '\n'

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -210,8 +210,8 @@ class Report(PlatformInfo, PythonInfo):
                     'Environment']:
             if key in repr_dict:
                 text += f'{key:>{row_width}} : {repr_dict[key]}\n'
-        for meta in self._extra_meta:
-            text += f'{meta[0]:>{row_width}} : {meta[1]}\n'
+        for key, value in self._extra_meta:
+            text += f'{key:>{row_width}} : {value}\n'
 
         # ########## Python details ############
         text += '\n'


### PR DESCRIPTION
Resolve #59 


```py
>>> scooby.Report(additional=['pydata_sphinx_theme'])

--------------------------------------------------------------------------------
  Date: Mon Apr 12 13:52:52 2021 MDT

                OS : Darwin
            CPU(s) : 16
           Machine : x86_64
      Architecture : 64bit
               RAM : 64.0 GiB
       Environment : Python

  Python 3.8.8 | packaged by conda-forge | (default, Feb 20 2021, 16:12:38)
  [Clang 11.0.1 ]

pydata_sphinx_theme : 0.6.0
              numpy : 1.18.1
              scipy : 1.4.1
            IPython : 7.14.0
         matplotlib : 3.2.1
             scooby : 0.5.6
--------------------------------------------------------------------------------
```