### PR TITLE
Add "File system" as OS/Platform detail

### DIFF
--- a/scooby/report.py
+++ b/scooby/report.py
@@ -175,7 +175,7 @@ class Report(PlatformInfo, PythonInfo):
         Additional two component pairs of meta information to display
 
     """
-    def __init__(self, additional=None, core=None, optional=None, ncol=3,
+    def __init__(self, additional=None, core=None, optional=None, ncol=4,
                  text_width=80, sort=False, extra_meta=None,):
 
         # Set default optional packages to investigate

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -76,14 +76,14 @@ class PlatformInfo:
     def filesystem(self):
         """Get the type of the file system at the path of the scooby package"""
         # Code by https://stackoverflow.com/a/35291824/10504481
-        mypath = str(Path(__file__).resolve())
-        bestMatch = ""
-        fsType = ""
+        my_path = str(Path(__file__).resolve())
+        best_match = ""
+        fs_type = ""
         for part in psutil.disk_partitions():
-            if mypath.startswith(part.mountpoint) and len(bestMatch) < len(part.mountpoint):
-                fsType = part.fstype
-                bestMatch = part.mountpoint
-        return fsType
+            if my_path.startswith(part.mountpoint) and len(best_match) < len(part.mountpoint):
+                fs_type = part.fstype
+                best_match = part.mountpoint
+        return fs_type
 
 
 class PythonInfo:

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -74,6 +74,7 @@ class PlatformInfo:
 
     @property
     def filesystem(self):
+        """Get the type of the file system at the path of the scooby package"""
         # Code by https://stackoverflow.com/a/35291824/10504481
         mypath = str(Path(__file__).resolve())
         bestMatch = ""

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -295,7 +295,7 @@ class Report(PlatformInfo, PythonInfo):
         repr_dict = self.to_dict()
         i = 0
         for key in ['OS', 'CPU(s)', 'Machine', 'Architecture', 'RAM',
-                    'Environment']:
+                    'Environment', "File system"]:
             if key in repr_dict:
                 html, i = cols(html, repr_dict[key], key, self.ncol, i)
         for meta in self._extra_meta:

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -221,7 +221,7 @@ class Report(PlatformInfo, PythonInfo):
         # ########## Platform/OS details ############
         repr_dict = self.to_dict()
         for key in ['OS', 'CPU(s)', 'Machine', 'Architecture', 'RAM',
-                    'Environment', 'File System']:
+                    'Environment', 'File system']:
             if key in repr_dict:
                 text += f'{key:>{row_width}} : {repr_dict[key]}\n'
         for key, value in self._extra_meta:
@@ -341,7 +341,7 @@ class Report(PlatformInfo, PythonInfo):
         out['CPU(s)'] = str(self.cpu_count)
         out['Machine'] = self.machine
         out['Architecture'] = self.architecture
-        out['File System'] = self.filesystem
+        out['File system'] = self.filesystem
         if TOTAL_RAM:
             out['RAM'] = self.total_ram
         out['Environment'] = self.python_environment


### PR DESCRIPTION
We recently encountered an issue which was related to the Filesystem in use. This was related to the use of a NFS File System.

I added this approach [https://stackoverflow.com/a/35291824/10504481](url) from the user gena2x to get the file system.

Tested with:

```py
import scooby
scooby.Report()
--------------------------------------------------------------------------------
  Date: Sun Apr 18 19:47:45 2021 Mitteleuropäische Sommerzeit
                OS : Windows
            CPU(s) : 16
           Machine : AMD64
      Architecture : 64bit
               RAM : 15.9 GiB
       Environment : Python
       File system : NTFS
  Python 3.9.4 (default, Apr  9 2021, 11:43:21) [MSC v.1916 64 bit (AMD64)]
```

```py
>>> import scooby
>>> scooby.Report()

--------------------------------------------------------------------------------
  Date: Sun Apr 18 19:51:57 2021 CEST

                OS : Linux
            CPU(s) : 32
           Machine : x86_64
      Architecture : 64bit
               RAM : 125.6 GiB
       Environment : Python
       File system : ext4

  Python 3.9.4 (default, Apr  9 2021, 16:34:09)  [GCC 7.3.0]

            scooby : 0.5.7
--------------------------------------------------------------------------------
```

```py
>>> import scooby
>>> scooby.Report()

--------------------------------------------------------------------------------
  Date: Sun Apr 18 19:52:33 2021 CEST

                OS : Linux
            CPU(s) : 12
           Machine : x86_64
      Architecture : 64bit
               RAM : 15.5 GiB
       Environment : Python
       File System : ext4

  Python 3.9.2 | packaged by conda-forge | (default, Feb 21 2021, 05:02:46)
  [GCC 9.3.0]

            scooby : 0.5.7
--------------------------------------------------------------------------------
```