### PR TITLE
Catch errors on import

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,3 +7,4 @@ mkl
 numpy
 scipy
 no_version
+pyvips

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -24,7 +24,8 @@ from .knowledge import (
     in_ipython,
 )
 
-MODULE_NOT_FOUND = 'Could not import'
+MODULE_NOT_FOUND = 'Module not found'
+MODULE_TROUBLE = 'Trouble importing'
 VERSION_NOT_FOUND = 'Version unknown'
 
 
@@ -396,6 +397,8 @@ def get_version(module):
             module = importlib.import_module(name)
         except ImportError:
             module = None
+        except:
+            return name, MODULE_TROUBLE
 
     elif isinstance(module, ModuleType):  # Case 2: module is module; get name
         name = module.__name__

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -397,7 +397,7 @@ def get_version(module):
             module = importlib.import_module(name)
         except ImportError:
             module = None
-        except:
+        except:  # noqa
             return name, MODULE_TROUBLE
 
     elif isinstance(module, ModuleType):  # Case 2: module is module; get name

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -161,3 +161,13 @@ def test_version_compare():
 
     with pytest.raises(ValueError):
         scooby.meets_version('0.25.2.0', '0.26')
+
+
+@pytest.mark.skipif(, 'pyvips is working')
+def test_import_os_error():
+    # pyvips requires libvips, etc., to be installed
+    # We don't have this on CI, so this should throw an error on import
+    # Make sure scooby can handle it.
+    with pytest.raises(OSError):
+        import pyvips  # noqa
+    assert scooby.Report(['pyvips'])

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -163,7 +163,6 @@ def test_version_compare():
         scooby.meets_version('0.25.2.0', '0.26')
 
 
-@pytest.mark.skipif(, 'pyvips is working')
 def test_import_os_error():
     # pyvips requires libvips, etc., to be installed
     # We don't have this on CI, so this should throw an error on import


### PR DESCRIPTION
A potential solution to #73 

This has a bare `except` which is frowned upon. Also the test I added here will only work if you have pyvips improperly installed. We may want a better test or to scrap this test