### PR TITLE
Better handling of file system for #78

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - name: Install Style dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/scooby/knowledge.py
+++ b/scooby/knowledge.py
@@ -37,7 +37,7 @@ except ImportError:
 # Get available RAM, if available
 if psutil:
     tmem = psutil.virtual_memory().total
-    TOTAL_RAM = '{:.1f} GiB'.format(tmem / (1024.0 ** 3))
+    TOTAL_RAM = '{:.1f} GiB'.format(tmem / (1024.0**3))
 else:
     TOTAL_RAM = False
 

--- a/scooby/knowledge.py
+++ b/scooby/knowledge.py
@@ -238,5 +238,5 @@ def get_filesystem_type():
                 fs_type = part.fstype
                 best_match = part.mountpoint
     else:
-        fs_type = 'unknown'
+        fs_type = False
     return fs_type

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -79,7 +79,9 @@ class PlatformInfo:
     @property
     def filesystem(self):
         """Get the type of the file system at the path of the scooby package"""
-        return get_filesystem_type()
+        if not hasattr(self, '_filesystem'):
+            self._filesystem = get_filesystem_type()
+        return self._filesystem
 
 
 class PythonInfo:
@@ -343,7 +345,8 @@ class Report(PlatformInfo, PythonInfo):
         out['CPU(s)'] = str(self.cpu_count)
         out['Machine'] = self.machine
         out['Architecture'] = self.architecture
-        out['File system'] = self.filesystem
+        if self.filesystem:
+            out['File system'] = self.filesystem
         if TOTAL_RAM:
             out['RAM'] = self.total_ram
         out['Environment'] = self.python_environment


### PR DESCRIPTION
If `psutil` is not installed, it will not know the file system.

Before #76, this was then simply omitted. Since then, it is always shown, but as `'unknown'` if `psutil` is not installed.

This PR undoes that.

I did also the following changes to the actions (if you prefer a separate PR @banesullivan let me know):
- `pythonpackage.yml`: Remove Python 3.6, add Python 3.10
- `lint.yml` & `release.yml`: Move from Python 3.8 to Python 3.9

Resolves #78 