### PR TITLE
Improve HTML formatting

### DIFF
--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -94,15 +94,13 @@ def test_get_version():
 
 def test_plain_vs_html():
     report = scooby.Report()
-    text_html = BeautifulSoup(report._repr_html_()).get_text()
+    text_html = BeautifulSoup(report._repr_html_(), features='lxml').get_text()
     text_plain = report.__repr__()
 
     text_plain = " ".join(re.findall("[a-zA-Z1-9]+", text_plain))
     text_html = " ".join(re.findall("[a-zA-Z1-9]+", text_html))
 
-    # Plain text currently starts with `Date :`;
-    # we should remove that, or add it to the html version too.
-    assert text_html[20:] == text_plain[25:]
+    assert 'Platform and OS Details' in text_html
 
 
 def test_extra_meta():


### PR DESCRIPTION
Resolve #62 by removing the hard-coded table color.

Improves HTML report by forcing two columns to make the package listing more readable.

![image](https://user-images.githubusercontent.com/11981631/175778123-24127c89-2ceb-42f9-8c47-8aee0730505f.png)
