### PR TITLE
Improve load time

### DIFF
--- a/scooby/knowledge.py
+++ b/scooby/knowledge.py
@@ -7,46 +7,11 @@ Knowledge
 It contains, for instance, known odd locations of version information for
 particular modules (``VERSION_ATTRIBUTES``, ``VERSION_METHODS``)
 
-It also checks and stores mandatory additional information, if possible, such
-as available RAM or MKL info.
-
 """
 import os
 from pathlib import Path
 import platform
 import sys
-
-try:
-    import psutil
-except ImportError:
-    psutil = False
-
-try:
-    import mkl
-
-    mkl.get_version_string()
-except (ImportError, AttributeError):
-    mkl = False
-
-try:
-    import numexpr
-except ImportError:
-    numexpr = False
-
-# Get available RAM, if available
-if psutil:
-    tmem = psutil.virtual_memory().total
-    TOTAL_RAM = '{:.1f} GiB'.format(tmem / (1024.0**3))
-else:
-    TOTAL_RAM = False
-
-# Get mkl info from numexpr or mkl, if available
-if mkl:
-    MKL_INFO = mkl.get_version_string()
-elif numexpr:
-    MKL_INFO = numexpr.get_vml_version()
-else:
-    MKL_INFO = False
 
 # Define unusual version locations
 VERSION_ATTRIBUTES = {
@@ -229,6 +194,11 @@ def meets_version(version, meets):
 
 def get_filesystem_type():
     """Get the type of the file system at the path of the scooby package."""
+    try:
+        import psutil  # lazy-load see PR#85
+    except ImportError:
+        psutil = False
+
     # Skip Windows due to https://github.com/banesullivan/scooby/issues/75
     if psutil and platform.system() != 'Windows':
         # Code by https://stackoverflow.com/a/35291824/10504481

--- a/scooby/knowledge.py
+++ b/scooby/knowledge.py
@@ -196,8 +196,8 @@ def get_filesystem_type():
         import psutil  # lazy-load see PR#85
     except ImportError:
         psutil = False
-    import platform  # lazy-load see PR#85
     from pathlib import Path  # lazy-load see PR#85
+    import platform  # lazy-load see PR#85
 
     # Skip Windows due to https://github.com/banesullivan/scooby/issues/75
     if psutil and platform.system() != 'Windows':

--- a/scooby/knowledge.py
+++ b/scooby/knowledge.py
@@ -111,7 +111,7 @@ def in_ipykernel():
 
 def get_standard_lib_modules():
     """Return a set of the names of all modules in the standard library."""
-    import distutils.sysconfig as sysconfig
+    import distutils.sysconfig as sysconfig  # lazy-load see PR#85
 
     if getattr(sys, 'frozen', False):  # within pyinstaller
         lib_path = os.path.join(sysconfig.get_python_lib(standard_lib=True), '..')

--- a/scooby/knowledge.py
+++ b/scooby/knowledge.py
@@ -11,7 +11,6 @@ It also checks and stores mandatory additional information, if possible, such
 as available RAM or MKL info.
 
 """
-import distutils.sysconfig as sysconfig
 import os
 from pathlib import Path
 import platform
@@ -111,6 +110,8 @@ def in_ipykernel():
 
 def get_standard_lib_modules():
     """Returns a set of the names of all modules in the standard library"""
+    import distutils.sysconfig as sysconfig
+
     if getattr(sys, 'frozen', False):  # within pyinstaller
         lib_path = os.path.join(sysconfig.get_python_lib(standard_lib=True), '..')
         if os.path.isdir(lib_path):

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -58,6 +58,7 @@ class PlatformInfo:
         """Return the number of CPUs in the system."""
         if not hasattr(self, '_cpu_count'):
             import multiprocessing  # lazy-load see PR#85
+
             self._cpu_count = multiprocessing.cpu_count()
         return self._cpu_count
 

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -1,7 +1,6 @@
 """The main module containing the `Report` class."""
 
 import importlib
-import multiprocessing
 import platform
 import sys
 import textwrap
@@ -57,7 +56,10 @@ class PlatformInfo:
     @property
     def cpu_count(self):
         """Return the number of CPUs in the system."""
-        return multiprocessing.cpu_count()
+        if not hasattr(self, '_cpu_count'):
+            import multiprocessing  # lazy-load see PR#85
+            self._cpu_count = multiprocessing.cpu_count()
+        return self._cpu_count
 
     @property
     def total_ram(self):

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -489,4 +489,5 @@ def get_version(module):
 def platform():
     """Return platform as lazy load; see PR#85."""
     import platform
+
     return platform

--- a/scooby/tracker.py
+++ b/scooby/tracker.py
@@ -24,11 +24,13 @@ MODULES_TO_IGNORE = {
     "mpl_toolkits",
 }
 
+STDLIB_PKGS = None
+
 
 def _criterion(name):
     if (
         len(name) > 0
-        and name not in get_standard_lib_modules()
+        and name not in STDLIB_PKGS
         and not name.startswith("_")
         and name not in MODULES_TO_IGNORE
     ):
@@ -51,6 +53,8 @@ def track_imports():
     """Track all imported modules for the remainder of this session."""
     if not TRACKING_SUPPORTED:
         raise RuntimeError(SUPPORT_MESSAGE)
+    global STDLIB_PKGS
+    STDLIB_PKGS = get_standard_lib_modules()
     builtins.__import__ = scooby_import
     return
 

--- a/scooby/tracker.py
+++ b/scooby/tracker.py
@@ -25,13 +25,10 @@ MODULES_TO_IGNORE = {
 }
 
 
-STDLIB_PKGS = get_standard_lib_modules()
-
-
 def _criterion(name):
     if (
         len(name) > 0
-        and name not in STDLIB_PKGS
+        and name not in get_standard_lib_modules()
         and not name.startswith("_")
         and name not in MODULES_TO_IGNORE
     ):

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -184,5 +184,5 @@ def test_import_time():
     # Capture it
     out = subprocess.run(cmd, capture_output=True)
 
-    # Currently we check t < 50 ms.
-    assert float(out.stderr.decode("utf-8")[:-1]) < 0.05
+    # Currently we check t < 0.15 s.
+    assert float(out.stderr.decode("utf-8")[:-1]) < 0.15

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -170,3 +170,18 @@ def test_import_os_error():
     with pytest.raises(OSError):
         import pyvips  # noqa
     assert scooby.Report(['pyvips'])
+
+
+@pytest.mark.skipif(not sys.platform.startswith('linux'), reason="Not Linux.")
+def test_import_time():
+    # Relevant for packages which provide a CLI:
+    # How long does it take to import?
+    cmd = ["time", "-f", "%U", "python", "-c", "import scooby"]
+    # Run it twice, just in case.
+    subprocess.run(cmd)
+    subprocess.run(cmd)
+    # Capture it
+    out = subprocess.run(cmd, capture_output=True)
+
+    # Currently we check t < 50 ms.
+    assert float(out.stderr.decode("utf-8")[:-1]) < 0.05

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -1,4 +1,5 @@
 import re
+import subprocess
 import sys
 
 from bs4 import BeautifulSoup


### PR DESCRIPTION
Helps #79 to speed up scooby import time since `distutils` is imported for a lesser used method `get_standard_lib_modules()`

We can remove/deprecate in a follow-up PR. This change speeds up the import time from 0.378s to 0.044s for me

cc @prisae 