### PR TITLE
Fix bug for empty package list

### DIFF
--- a/scooby/report.py
+++ b/scooby/report.py
@@ -224,7 +224,10 @@ class Report(PlatformInfo, PythonInfo):
         text += date_text + '\n'
 
         # Get length of longest package: min of 18 and max of 40
-        row_width = min(40, max(18, len(max(self._packages.keys(), key=len))))
+        if self._packages:
+            row_width = min(40, max(18, len(max(self._packages.keys(), key=len))))
+        else:
+            row_width = 40
 
         # ########## Platform/OS details ############
         repr_dict = self.to_dict()
@@ -238,7 +241,8 @@ class Report(PlatformInfo, PythonInfo):
         text += '\n'
         for txt in textwrap.wrap('Python ' + self.sys_version, self.text_width - 4):
             text += '  ' + txt + '\n'
-        text += '\n'
+        if self._packages:
+            text += '\n'
 
         # Loop over packages
         for name, version in self._packages.items():

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -227,7 +227,7 @@ class Report(PlatformInfo, PythonInfo):
         if self._packages:
             row_width = min(40, max(18, len(max(self._packages.keys(), key=len))))
         else:
-            row_width = 40
+            row_width = 18
 
         # ########## Platform/OS details ############
         repr_dict = self.to_dict()


### PR DESCRIPTION
Currently, the `Report()` fails if there is an empty package list, which you get if you call
```
import scooby
scooby.Report(optional=[])
```

This PR fixes this, so it works just nicely (it always worked with the `_repr_html`, there was no issue there).

Example output (with the fix):
```
--------------------------------------------------------------------------------
  Date: Fri Jul 22 17:08:49 2022 CEST

                                      OS : Linux
                                  CPU(s) : 4
                                 Machine : x86_64
                            Architecture : 64bit
                                     RAM : 7.7 GiB
                             Environment : IPython
                             File system : ext4

  Python 3.9.10 | packaged by conda-forge | (main, Feb  1 2022, 21:24:11)
  [GCC 9.4.0]

  Intel(R) oneAPI Math Kernel Library Version 2022.0-Product Build 20211112
  for Intel(R) 64 architecture applications
--------------------------------------------------------------------------------
```

This came up in the introduction of the `--no-opt`-flag for the CLI in #86 - but I thought I'd open a separate PR, as this bug is not really related to the CLI.