### PR TITLE
Introduce a compact layout for ncol=1

### DIFF
--- a/scooby/report.py
+++ b/scooby/report.py
@@ -161,20 +161,23 @@ class Report(PlatformInfo, PythonInfo):
     optional : list(ModuleType), list(str)
         A list of packages to list if they are available. If not available,
         no warnings or error will be thrown.
-        Defaults to ['numpy', 'scipy', 'IPython', 'matplotlib', 'scooby']
+        Defaults to ``['numpy', 'scipy', 'IPython', 'matplotlib', 'scooby']``
 
     ncol : int, optional
         Number of package-columns in html table (no effect in text-version);
         Defaults to 3.
 
     text_width : int, optional
-        The text width for non-HTML display modes
+        The text width for non-HTML display modes.
 
     sort : bool, optional
-        Sort the packages when the report is shown
+        Sort the packages when the report is shown.
 
-    extra_meta : tuple(str, str)
-        Additional two component pairs of meta information to display
+    extra_meta : tuple(str, str), optional
+        Additional two component pairs of meta information to display.
+
+    max_width : int, optional
+        Max-width of html-table. By default None.
 
     """
 
@@ -187,6 +190,7 @@ class Report(PlatformInfo, PythonInfo):
         text_width=80,
         sort=False,
         extra_meta=None,
+        max_width=None,
     ):
         """Initialize report."""
         # Set default optional packages to investigate
@@ -196,6 +200,7 @@ class Report(PlatformInfo, PythonInfo):
         PythonInfo.__init__(self, additional=additional, core=core, optional=optional, sort=sort)
         self.ncol = int(ncol)
         self.text_width = int(text_width)
+        self.max_width = max_width
 
         if extra_meta is not None:
             if not isinstance(extra_meta, (list, tuple)):
@@ -226,7 +231,7 @@ class Report(PlatformInfo, PythonInfo):
         # Get length of longest package: min of 18 and max of 40
         row_width = min(40, max(18, len(max(self._packages.keys(), key=len))))
 
-        # ########## Platform/OS details ############
+        # Platform/OS details
         repr_dict = self.to_dict()
         for key in ['OS', 'CPU(s)', 'Machine', 'Architecture', 'RAM', 'Environment', 'File system']:
             if key in repr_dict:
@@ -234,7 +239,7 @@ class Report(PlatformInfo, PythonInfo):
         for key, value in self._extra_meta:
             text += f'{key:>{row_width}} : {value}\n'
 
-        # ########## Python details ############
+        # Python details
         text += '\n'
         for txt in textwrap.wrap('Python ' + self.sys_version, self.text_width - 4):
             text += '  ' + txt + '\n'
@@ -244,13 +249,13 @@ class Report(PlatformInfo, PythonInfo):
         for name, version in self._packages.items():
             text += f'{name:>{row_width}} : {version}\n'
 
-        # ########## MKL details ############
+        # MKL details
         if MKL_INFO:
             text += '\n'
             for txt in textwrap.wrap(MKL_INFO, self.text_width - 4):
                 text += '  ' + txt + '\n'
 
-        # ########## Finish ############
+        # Finish
         text += self.text_width * '-'
 
         return text
@@ -263,13 +268,17 @@ class Report(PlatformInfo, PythonInfo):
         def colspan(html, txt, ncol, nrow):
             r"""Print txt in a row spanning whole table."""
             html += "  <tr>\n"
-            html += "     <td style='text-align: center; "
+            html += "     <td style='"
+            if ncol == 1:
+                html += "text-align: left; "
+            else:
+                html += "text-align: center; "
             if nrow == 0:
                 html += "font-weight: bold; font-size: 1.2em; "
             elif nrow % 2 == 0:
                 html += "background-color: #ddd;"
             html += border + " colspan='"
-            html += str(2 * ncol) + "'>%s</td>\n" % txt
+            html += f"{2 * ncol}'>{txt}</td>\n"
             html += "  </tr>\n"
             return html
 
@@ -280,7 +289,8 @@ class Report(PlatformInfo, PythonInfo):
                 html += "  </tr>\n"
                 html += "  <tr>\n"
 
-            html += "    <td style='text-align: right; background-color: #ccc;"
+            align = "left" if ncol == 1 else "right"
+            html += f"    <td style='text-align: {align}; background-color: #ccc;"
             html += " " + border + ">%s</td>\n" % name
 
             html += "    <td style='text-align: left; "
@@ -289,12 +299,15 @@ class Report(PlatformInfo, PythonInfo):
             return html, i + 1
 
         # Start html-table
-        html = "<table style='border: 3px solid #ddd;'>\n"
+        html = "<table style='border: 3px solid #ddd;"
+        if self.max_width:
+            html += f" max-width: {self.max_width}px;"
+        html += "'>\n"
 
         # Date and time info as title
         html = colspan(html, self.date, self.ncol, 0)
 
-        # ########## Platform/OS details ############
+        # Platform/OS details
         html += "  <tr>\n"
         repr_dict = self.to_dict()
         i = 0
@@ -306,10 +319,10 @@ class Report(PlatformInfo, PythonInfo):
         # Finish row
         html += "  </tr>\n"
 
-        # ########## Python details ############
+        # Python details
         html = colspan(html, 'Python ' + self.sys_version, self.ncol, 1)
-
         html += "  <tr>\n"
+
         # Loop over packages
         i = 0  # Reset count for rows.
         for name, version in self.packages.items():
@@ -322,11 +335,11 @@ class Report(PlatformInfo, PythonInfo):
         # Finish row
         html += "  </tr>\n"
 
-        # ########## MKL details ############
+        # MKL details
         if MKL_INFO:
             html = colspan(html, MKL_INFO, self.ncol, 2)
 
-        # ########## Finish ############
+        # Finish
         html += "</table>"
 
         return html


### PR DESCRIPTION
My proposition as an alternative to #82  @akaszynski - what do you think?

It does the following:
- If `ncol=1`, it left-aligns everything.
- It adds a new `max-width` parameter, with which the user can control the max-width of the table.
- I tried to include all the other little cleaning-up bits you put into #82.

An example how this "compact" layout looks:
![2022-07-22-01](https://user-images.githubusercontent.com/8020943/180517540-90e5a9c6-a8f7-4837-917c-9f999c02e5ca.png)
 