### PR TITLE
Bump main to 0.7.dev0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import io
 
 import setuptools
 
-__version__ = '0.5.12'
+__version__ = '0.7.dev0'
 
 with io.open("README.md", "r", encoding="utf-8") as f:
     long_description = f.read()


### PR DESCRIPTION
This follows the [trunk based development](https://trunkbaseddevelopment.com/) release pattern used for PyVista by:
- Setting the `main` branch to MAJOR.<MINOR + 1>.dev0
- Follow semantic versioning by creating release branches so we can do patch releases for bug fixes without having to make a new minor release.
- Getting us ready to bump the release branch and tag it.