### PR TITLE
setuptools_scm

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,8 +1,0 @@
-[bumpversion]
-current_version = 0.5.12
-commit = True
-tag = True
-
-[bumpversion:file:setup.py]
-
-[bumpversion:file:scooby/__init__.py]

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -18,7 +18,13 @@ jobs:
         python-version: [3.7, 3.8, 3.9, "3.10"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 100
+        persist-credentials: false
+    - name: Fetch git tags
+      run: git fetch origin 'refs/tags/*:refs/tags/*'
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine
+          pip install setuptools setuptools_scm wheel twine
       - name: Build and Install Wheel
         run: |
           python setup.py bdist_wheel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,13 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 100
+          persist-credentials: false
+      - name: Fetch git tags
+        run: git fetch origin 'refs/tags/*:refs/tags/*'
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.egg-info/
 build/
 dist/
+scooby/version.py
 
 # Mac
 .DS_Store

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,13 @@
-include *.rst LICENSE
-include README.md
+prune assets
+prune tests
+prune .github
+exclude codecov.yml
+exclude Makefile
+exclude MANIFEST.in
+exclude pyproject.toml
+exclude requirements_style.txt
+exclude requirements_test.txt
+exclude requirements.txt
+exclude .flake8
+exclude .gitignore
+exclude .pre-commit-config.yaml

--- a/scooby/__init__.py
+++ b/scooby/__init__.py
@@ -43,4 +43,8 @@ __all__ = [
 __author__ = 'Dieter Werthmüller, Bane Sullivan, Alex Kaszynski, and contributors'
 __license__ = 'MIT'
 __copyright__ = '2019, Dieter Werthmüller & Bane Sullivan'
-__version__ = '0.7.dev0'
+try:
+    from scooby.version import version as __version__
+except ImportError:  # Only happens if not properly installed.
+    from datetime import datetime
+    __version__ = 'unknown-'+datetime.today().strftime('%Y%m%d')

--- a/scooby/__init__.py
+++ b/scooby/__init__.py
@@ -47,4 +47,5 @@ try:
     from scooby.version import version as __version__
 except ImportError:  # Only happens if not properly installed.
     from datetime import datetime
-    __version__ = 'unknown-'+datetime.today().strftime('%Y%m%d')
+
+    __version__ = 'unknown-' + datetime.today().strftime('%Y%m%d')

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-import os
 import io
+import os
 
 import setuptools
 

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,14 @@
 # coding=utf-8
+import os
 import io
 
 import setuptools
-
-__version__ = '0.7.dev0'
 
 with io.open("README.md", "r", encoding="utf-8") as f:
     long_description = f.read()
 
 setuptools.setup(
     name="scooby",
-    version=__version__,
     author="Dieter Werthmüller, Bane Sullivan, Alex Kaszynski, and contributors",
     author_email="info@pyvista.org",
     description="A Great Dane turned Python environment detective",
@@ -30,4 +28,10 @@ setuptools.setup(
         'cpu': ['psutil', 'mkl'],
         # 'gpu': [], # TODO: what's needed?
     },
+    use_scm_version={
+        "root": ".",
+        "relative_to": __file__,
+        "write_to": os.path.join("scooby", "version.py"),
+    },
+    setup_requires=["setuptools_scm"],
 )


### PR DESCRIPTION
This PR is mainly meant for discussion. These would be the changes required to change to `setuptools_scm`.

The advantage of this approach is that you never have to hard-code a version any longer. The version numbers are created when installing it (e.g., `pip install -e .` or similar) and placed in `scooby/version.py`.

Example of version numbers:
- Released versions just tags       : 0.6.0
- GitHub commits add .dev#+hash     : 0.6.0.dev4+g2785721
- Uncommitted changes add timestamp : 0.6.0.dev4+g2785721.d20220727

If scooby is not properly installed, e.g., the folder is copied somewhere without the `.git/`-information, then the version will be unknown plus date: `unknown-20220727`.

If you don't like this approach we can close this PR again.

Either way, I just found out that this setup does not seem to work with the release-branch setup that was implemented in https://github.com/banesullivan/scooby/pull/90 - because installing it now results in a version number `v0.5.13.dev...`, so it does not recognize the tag `Releases/v0.6.0`. This means, if we want to use this we would either have to revert the release branches approach, or adjust my implementation here. As in this approach there are never two commits with identical version numbers, I think we could simply get rid of the release branches again.
**Edit:** To support release branches, we have to add
```
    "version_scheme": "release-branch-semver",
```
to the `use_scm_version`-dict in `setup.py`. But I guess first we decide if we keep release branches or not.

There is one oddity that you might see when looking through the changes: `MANIFEST.in` is normally used to include files. `setuptools_scm` reverts that, so everything is included by default, and `MANIFEST.in` is used to _exclude_ files.

### TODO
- [ ] Decide yes/no for setuptools_scm.
- [ ] Decide yes/no for release branches; adjust this PR accordingly.
- [ ] The conda-recipe would need adjustments to include `setuptools_scm` to `requirements: host:`.