### PR TITLE
Add package resources version fallback

### DIFF
--- a/scooby/report.py
+++ b/scooby/report.py
@@ -427,7 +427,8 @@ def pkg_resources_version_fallback(name):
         return
     try:
         return get_distribution(name).version
-    except DistributionNotFound:  # pragma: no cover
+    except (DistributionNotFound, Exception):  # pragma: no cover
+        # Can run into ParseException, etc. when a bad name is passed
         pass
 
 

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -87,7 +87,7 @@ def test_get_version():
     assert version == numpy.__version__
     assert name == "numpy"
     name, version = scooby.get_version("no_version")
-    assert version == scooby.report.VERSION_NOT_FOUND
+    assert version == "0.1.0"  # Assuming this package never updates
     assert name == "no_version"
     name, version = scooby.get_version("does_not_exist")
     assert version == scooby.report.MODULE_NOT_FOUND


### PR DESCRIPTION
Fixes an issue where our typical methods of uncovering a version fail for some packages by falling back to package-resoources if available to get the distribution version.

There may be justification for making this the default, but for now, I have tagged it on as a final fallback.

One particular package that needs this is `pythreejs`.

Main:

```
$ scooby pythreejs

--------------------------------------------------------------------------------

...

  Python 3.9.13 (main, Aug 25 2022, 18:24:45)  [Clang 12.0.0 ]

         pythreejs : Version unknown
```

This branch

```
$ scooby pythreejs

--------------------------------------------------------------------------------

...

  Python 3.9.13 (main, Aug 25 2022, 18:24:45)  [Clang 12.0.0 ]

         pythreejs : 2.4.1
```