### PR TITLE
Replace no_version from PyPI to local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ scooby/version.py
 .pytest_cache/
 tests/.coverage
 tests/htmlcov/
-no_version/
+tests/no_version/
 
 # windows
 test.bat

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ scooby/version.py
 .pytest_cache/
 tests/.coverage
 tests/htmlcov/
-tests/no_version/
+tests/dummy_module/
 
 # windows
 test.bat

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ scooby/version.py
 .pytest_cache/
 tests/.coverage
 tests/htmlcov/
+no_version/
 
 # windows
 test.bat

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,5 +7,4 @@ psutil
 mkl
 numpy
 scipy
-no_version
 pyvips

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,4 +7,5 @@ psutil
 mkl
 numpy
 scipy
+no_version
 pyvips

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -150,8 +150,8 @@ def test_tracking():
 
     report = scooby.TrackedReport()
     scooby.untrack_imports()
-    import no_version  # noqa
     import dummy_module  # noqa
+    import no_version  # noqa
 
     assert "numpy" in report.packages
     assert "scipy" in report.packages

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -10,6 +10,19 @@ import pytest
 import scooby
 
 
+# Write a package `no_version` without version number.
+try:
+    os.mkdir("no_version")
+except FileExistsError:
+    pass
+
+with open(os.path.join("no_version", "__init__.py"), "w") as f:
+    f.write("info = 'Package without __version__ number.'\n")
+
+
+import no_version
+
+
 def test_report():
     report = scooby.Report()
     text = str(report)
@@ -87,7 +100,7 @@ def test_get_version():
     assert version == numpy.__version__
     assert name == "numpy"
     name, version = scooby.get_version("no_version")
-    assert version == "0.1.0"  # Assuming this package never updates
+    assert version == scooby.report.VERSION_NOT_FOUND
     assert name == "no_version"
     name, version = scooby.get_version("does_not_exist")
     assert version == scooby.report.MODULE_NOT_FOUND

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -23,9 +23,6 @@ with open(os.path.join(ppath, "__init__.py"), "w") as f:
 sys.path.append('tests')
 
 
-import no_version
-
-
 def test_report():
     report = scooby.Report()
     text = str(report)

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -9,7 +9,6 @@ import pytest
 
 import scooby
 
-
 # Write a package `no_version` without version number.
 ppath = os.path.join("tests", "no_version")
 try:

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -11,13 +11,16 @@ import scooby
 
 
 # Write a package `no_version` without version number.
+ppath = os.path.join("tests", "no_version")
 try:
-    os.mkdir("no_version")
+    os.mkdir(ppath)
 except FileExistsError:
     pass
 
-with open(os.path.join("no_version", "__init__.py"), "w") as f:
+with open(os.path.join(ppath, "__init__.py"), "w") as f:
     f.write("info = 'Package without __version__ number.'\n")
+
+sys.path.append('tests')
 
 
 import no_version

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -151,10 +151,12 @@ def test_tracking():
     report = scooby.TrackedReport()
     scooby.untrack_imports()
     import no_version  # noqa
+    import dummy_module  # noqa
 
     assert "numpy" in report.packages
     assert "scipy" in report.packages
     assert "no_version" not in report.packages
+    assert "dummy_module" not in report.packages
     assert "pytest" not in report.packages
     assert "mu_0" not in report.packages
 

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -9,8 +9,8 @@ import pytest
 
 import scooby
 
-# Write a package `no_version` without version number.
-ppath = os.path.join("tests", "no_version")
+# Write a package `dummy_module` without version number.
+ppath = os.path.join("tests", "dummy_module")
 try:
     os.mkdir(ppath)
 except FileExistsError:
@@ -98,9 +98,17 @@ def test_get_version():
     name, version = scooby.get_version(numpy)
     assert version == numpy.__version__
     assert name == "numpy"
+
+    # Package that was no version given by owner; gets 0.1.0 from setup/pip
     name, version = scooby.get_version("no_version")
-    assert version == scooby.report.VERSION_NOT_FOUND
+    assert version == "0.1.0"
     assert name == "no_version"
+
+    # Dummy module without version (not installed properly)
+    name, version = scooby.get_version("dummy_module")
+    assert version == scooby.report.VERSION_NOT_FOUND
+    assert name == "dummy_module"
+
     name, version = scooby.get_version("does_not_exist")
     assert version == scooby.report.MODULE_NOT_FOUND
     assert name == "does_not_exist"


### PR DESCRIPTION
Create a local dummy package without a version. Because pip/PyPI gives it automatically a version number 0.1.0 if None is provided.