### PR TITLE
Remove use of pkg_resources for importlib.metadata

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.11"
 
       - name: Install pre-commit
         run: pip install pre-commit

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
     - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -278,10 +278,7 @@ else:
 A couple of locations are checked, and we are happy to implement more if
 needed, just open an issue!
 
-Currently, it looks in the following places:
-- `__version__`
-- `version`
-- lookup distribution version with `importlib.metadata.version`
+Currently, it uses `importlib.metadata.version` to get the distribution version.
 
 ### Using scooby to get version information.
 

--- a/README.md
+++ b/README.md
@@ -281,20 +281,7 @@ needed, just open an issue!
 Currently, it looks in the following places:
 - `__version__`
 - `version`
-- lookup `VERSION_ATTRIBUTES` in the scooby knowledge base
-- lookup `VERSION_METHODS` in the scooby knowledge base
-
-`VERSION_ATTRIBUTES` is a dictionary of attributes for known python packages
-with a non-standard place for the version, e.g. `VERSION_ATTRIBUTES['vtk'] =
-'VTK_VERSION'`. You can add other known places via:
-
-```py
-scooby.knowledge.VERSION_ATTRIBUTES['a_module'] = 'Awesome_version_location'
-```
-
-Similarly, `VERSION_METHODS` is a dictionary for methods to retrieve the
-version, and you can similarly add your methods which will get the version
-of a package.
+- lookup distribution version with `importlib.metadata.version`
 
 ### Using scooby to get version information.
 

--- a/scooby/knowledge.py
+++ b/scooby/knowledge.py
@@ -4,33 +4,12 @@ The knowledge base.
 Knowledge
 =========
 
-It contains, for instance, known odd locations of version information for
-particular modules (``VERSION_ATTRIBUTES``, ``VERSION_METHODS``)
+Utilities for detecting the environment.
 
 """
 import os
 import sys
 import sysconfig
-
-# Define unusual version locations
-VERSION_ATTRIBUTES = {
-    'vtk': 'VTK_VERSION',
-    'vtkmodules.all': 'VTK_VERSION',
-    'PyQt5': 'Qt.PYQT_VERSION_STR',
-    'sip': 'SIP_VERSION_STR',
-}
-
-
-def get_pyqt5_version():
-    """Return the PyQt5 version."""
-    from PyQt5.Qt import PYQT_VERSION_STR
-
-    return PYQT_VERSION_STR
-
-
-VERSION_METHODS = {
-    'PyQt5': get_pyqt5_version,
-}
 
 
 # Check the environments

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -435,49 +435,23 @@ def get_version(module):
     # If (1), we have to load it, if (2), we have to get its name.
     if isinstance(module, str):  # Case 1: module is a string; import
         name = module  # The name is stored in module in this case.
-
-        # Import module `name`; set to None if it fails.
-        try:
-            module = importlib.import_module(name)
-        except ImportError:
-            module = None
-        except:  # noqa
-            return name, MODULE_TROUBLE
-
     elif isinstance(module, ModuleType):  # Case 2: module is module; get name
         name = module.__name__
-
     else:  # If not str nor module raise error
         raise TypeError("Cannot fetch version from type " "({})".format(type(module)))
 
-    ver = None
-    # Now get the version info from the module
-    if module is None:
-        try:
-            ver = importlib.metadata.version(name)
-            return name, ver
-        except (importlib.metadata.PackageNotFoundError):
-            pass
+    # Use importlib.metadata to get the version
+    try:
+        ver = importlib.metadata.version(name)
+    except (importlib.metadata.PackageNotFoundError):  # pragma: no cover
         return name, MODULE_NOT_FOUND
-    else:
-        # Try common version names.
-        for v_string in ('__version__', 'version'):
-            try:
-                ver = getattr(module, v_string)
-                if isinstance(ver, str):
-                    return name, ver
-            except AttributeError:
-                pass
+    except:  # noqa
+        return name, MODULE_TROUBLE
 
-        # Try importlib distribution version
-        try:
-            ver = importlib.metadata.version(name)
-            return name, ver
-        except (importlib.metadata.PackageNotFoundError):  # pragma: no cover
-            pass
-
-        # If not found, return VERSION_NOT_FOUND
+    if ver is None:
         return name, VERSION_NOT_FOUND
+
+    return name, ver
 
 
 def platform():

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
         'Intended Audience :: Science/Research',
         'Natural Language :: English',
     ),
-    python_requires='>=3.7.*',
+    python_requires='>=3.8.*',
     extras_require={
         'cpu': ['psutil', 'mkl'],
         # 'gpu': [], # TODO: what's needed?

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -8,6 +8,7 @@ import numpy
 import pytest
 
 import scooby
+from scooby.report import NOT_PROPERLY_INSTALLED, VERSION_NOT_FOUND
 
 # Write a package `dummy_module` without version number.
 ppath = os.path.join("tests", "dummy_module")
@@ -106,7 +107,7 @@ def test_get_version():
 
     # Path dummy module (not installed properly)
     name, version = scooby.get_version("dummy_module")
-    assert version == scooby.report.MODULE_NOT_FOUND
+    assert version == f'{VERSION_NOT_FOUND} {NOT_PROPERLY_INSTALLED}'
     assert name == "dummy_module"
 
     name, version = scooby.get_version("does_not_exist")

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -97,7 +97,7 @@ def test_ipy():
 
 def test_get_version():
     name, version = scooby.get_version(numpy)
-    # assert version == numpy.__version__
+    assert version == numpy.__version__
     assert name == "numpy"
 
     # Package that has no `__version__` but has `0.1.0` from distribution

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -96,17 +96,17 @@ def test_ipy():
 
 def test_get_version():
     name, version = scooby.get_version(numpy)
-    assert version == numpy.__version__
+    # assert version == numpy.__version__
     assert name == "numpy"
 
-    # Package that was no version given by owner; gets 0.1.0 from setup/pip
+    # Package that has no `__version__` but has `0.1.0` from distribution
     name, version = scooby.get_version("no_version")
     assert version == "0.1.0"
     assert name == "no_version"
 
-    # Dummy module without version (not installed properly)
+    # Path dummy module (not installed properly)
     name, version = scooby.get_version("dummy_module")
-    assert version == scooby.report.VERSION_NOT_FOUND
+    assert version == scooby.report.MODULE_NOT_FOUND
     assert name == "dummy_module"
 
     name, version = scooby.get_version("does_not_exist")

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -105,7 +105,7 @@ def test_get_version():
     assert version == "0.1.0"
     assert name == "no_version"
 
-    # Path dummy module (not installed properly)
+    # Path dummy module without version (not installed properly)
     name, version = scooby.get_version("dummy_module")
     assert version == f'{VERSION_NOT_FOUND} {NOT_PROPERLY_INSTALLED}'
     assert name == "dummy_module"


### PR DESCRIPTION
Follow up to #101 to use `importlib.metadata` as it is preferred. This refactors `get_version()` and the `knowledge` module quite a bit to remove unneeded logic as `importlib.metadata.version` can do much of (all?) what we need!

Further this, necessarily, drops support for Python 3.7.

Do not merge until we are ready to drop Python 3.7 support, which, IMO should match when PyVista drops 3.7 as that's the primary downstream dependency from my perspective