### PR TITLE
Replace bs4 with beautifulsoup4

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,7 +2,7 @@ pytest
 pytest-console-scripts
 pytest-cov
 codecov
-bs4
+beautifulsoup4
 psutil
 mkl
 numpy


### PR DESCRIPTION
`bs4` is a dummy package. It's published on PyPI but distributions usually only ship `beautifulsoup4`.