### PR TITLE
setup.py: fix python_requires version specifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
         'Intended Audience :: Science/Research',
         'Natural Language :: English',
     ),
-    python_requires='>=3.7.*',
+    python_requires='>=3.7',
     extras_require={
         'cpu': ['psutil', 'mkl'],
         # 'gpu': [], # TODO: what's needed?

--- a/setup.py
+++ b/setup.py
@@ -21,13 +21,13 @@ setuptools.setup(
             "scooby=scooby.__main__:main",
         ],
     },
-    classifiers=(
+    classifiers=[
         "Programming Language :: Python",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         'Intended Audience :: Science/Research',
         'Natural Language :: English',
-    ),
+    ],
     python_requires='>=3.7',
     extras_require={
         'cpu': ['psutil', 'mkl'],


### PR DESCRIPTION
Using `3.7.*` was turned into an error by a recent version of `packaging` and won't allow installing, see
https://github.com/pypa/packaging/commit/068a0b5975a95a5cc30262599ca29bb6ceabe4af