### PR TITLE
Fix `codecov` to Use New Uploader

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -44,7 +44,7 @@ jobs:
       run: make apitest
     - name: Doctests
       run: make doctest
-    - uses: codecov/codecov-action@v2
+    - uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.xml

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,6 @@
 pytest
 pytest-console-scripts
 pytest-cov
-codecov
 beautifulsoup4
 psutil
 mkl


### PR DESCRIPTION
This PR addresses issue #110 by removing `codecov` from `requirements_test.txt` and updating the `codecov` `GitHub Action` in `pythonpackage.yml` to `v3` (`v2+` required to use new uploader instead of `bash` uploader).

This should completely fix the issue, but in case additional steps are required to properly setup `codecov`, a repository admin may need to perform additional steps from the [deprecation guide](https://docs.codecov.com/docs/deprecated-uploader-migration-guide).