### PR TITLE
.pre-commit-config.yaml: Upgrade isort to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
   - id: black
 
 - repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
   - id: isort
 


### PR DESCRIPTION
This should fix:

```
raise RuntimeError("The Poetry configuration is invalid:\n" + message)
RuntimeError: The Poetry configuration is invalid:
- [extras.pipfile_deprecated_finder.2] 'pip-shims<=0.3.4' does not match '^[a-zA-Z-_.0-9]+$'
```

It does and then ends up with this message:

```
[INFO] Installing environment for https://github.com/pycqa/pydocstyle.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
black....................................................................Passed
isort....................................................................Passed
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

scooby/__main__.py:58:1: BLK100 Black would make changes.
scooby/report.py:68:1: BLK100 Black would make changes.
tests/test_scooby.py:216:1: BLK100 Black would make changes.

codespell................................................................Passed
pydocstyle...............................................................Passed
check for merge conflicts................................................Passed
debug statements (python)................................................Passed
don't commit to branch...................................................Passed
Error: Process completed with exit code 1.
```