### PR TITLE
Drop Python 3.7

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
     - name: Checkout

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
         "Intended Audience :: Science/Research",
         "Natural Language :: English",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     extras_require={
         "cpu": ["psutil", "mkl"],
     },


### PR DESCRIPTION
Dropping Python 3.7 support given that it is past end of life and PyVista has dropped it. See also https://github.com/banesullivan/scooby/pull/109#issuecomment-1732663856

cc @Gryfenfer97 