### PR TITLE
importlib.metadata.version is now default mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,8 +285,7 @@ Currently, it looks in the following places:
 - lookup `VERSION_METHODS` in the scooby knowledge base
 
 `VERSION_ATTRIBUTES` is a dictionary of attributes for known python packages
-with a non-standard place for the version, e.g. `VERSION_ATTRIBUTES['vtk'] =
-'VTK_VERSION'`. You can add other known places via:
+with a non-standard place for the version. You can add other known places via:
 
 ```py
 scooby.knowledge.VERSION_ATTRIBUTES['a_module'] = 'Awesome_version_location'

--- a/scooby/knowledge.py
+++ b/scooby/knowledge.py
@@ -13,10 +13,13 @@ import sys
 import sysconfig
 from typing import Callable, Dict, List, Literal, Set, Tuple, Union
 
+PACKAGE_ALIASES = {
+    'vtkmodules': 'vtk',
+    'vtkmodules.all': 'vtk',
+}
+
 # Define unusual version locations
 VERSION_ATTRIBUTES = {
-    'vtk': 'VTK_VERSION',
-    'vtkmodules.all': 'VTK_VERSION',
     'PyQt5': 'Qt.PYQT_VERSION_STR',
     'sip': 'SIP_VERSION_STR',
 }

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -215,7 +215,7 @@ def test_import_time():
 def test_cli(script_runner):
     # help
     for inp in ['--help', '-h']:
-        ret = script_runner.run('scooby', inp)
+        ret = script_runner.run(['scooby', inp])
         assert ret.success
         assert "Great Dane turned Python environment detective" in ret.stdout
 
@@ -231,12 +231,12 @@ def test_cli(script_runner):
         return out
 
     # default: scooby-Report
-    ret = script_runner.run('scooby')
+    ret = script_runner.run(['scooby'])
     assert ret.success
     assert rep_comp(scooby.Report().__repr__()) == rep_comp(ret.stdout)
 
     # default: scooby-Report with sort and no-opt
-    ret = script_runner.run('scooby', 'numpy', '--no-opt', '--sort')
+    ret = script_runner.run(['scooby', 'numpy', '--no-opt', '--sort'])
     assert ret.success
     test = scooby.Report('numpy', optional=[], sort=True).__repr__()
     print(rep_comp(test))
@@ -244,11 +244,11 @@ def test_cli(script_runner):
     assert rep_comp(test) == rep_comp(ret.stdout)
 
     # version -- VIA scooby/__main__.py by calling the folder scooby.
-    ret = script_runner.run('python', 'scooby', '--version')
+    ret = script_runner.run(['python', 'scooby', '--version'])
     assert ret.success
     assert "scooby v" in ret.stdout
 
     # version -- VIA scooby/__main__.py by calling the file.
-    ret = script_runner.run('python', os.path.join('scooby', '__main__.py'), '--version')
+    ret = script_runner.run(['python', os.path.join('scooby', '__main__.py'), '--version'])
     assert ret.success
     assert "scooby v" in ret.stdout


### PR DESCRIPTION
Follow up to #101 to make `importlib.metadata`'s `version` the default mechanism for retrieving package versions now that scooby is Python 3.8+ and this module is no longer provisional as of Python 3.10

Also cleans up a deprecation warning for a testing tool