### PR TITLE
Autogenerate Reports for any package and its dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,24 +363,49 @@ Scooby comes with a command-line interface. Simply typing
 scooby
 ```
 
-in a terminal will display the default report. You can also use it to show the
-scooby-report of another package: if that package has scooby implemented as
-suggested above, using `packagename.Report()`, otherwise it will get that
-packages dependences from its distribution to generate a report.
+in a terminal will display the default report. You can also use the CLI to show
+the scooby Report of another package if that package has scooby implemented as
+suggested above, using `packagename.Report()`.
 
 As an example, to print the report of pyvista you can run
 
 ```bash
-scooby --report pyvista
+scooby -r pyvista
 ```
 
 which will show the report implemented in PyVista.
 
-Or you could generate a report of a package and its dependencies that hasn't
-implemented a report class:
+The CLI can also generate a report based on the dependencies of a package's
+distribution where that package hasn't implemented a report class. For example,
+we can generate a Report on `matplotlib` and its dependencies:
 
 ```bash
-scooby --report matplotlib
+$ scooby -r matplotlib
+--------------------------------------------------------------------------------
+  Date: Fri Oct 20 16:28:13 2023 PDT
+
+                OS : Darwin
+            CPU(s) : 8
+           Machine : arm64
+      Architecture : 64bit
+               RAM : 16.0 GiB
+       Environment : Python
+       File system : apfs
+
+  Python 3.11.3 | packaged by conda-forge | (main, Apr  6 2023, 08:58:31)
+  [Clang 14.0.6 ]
+
+        matplotlib : 3.7.1
+         contourpy : 1.0.7
+            cycler : 0.11.0
+         fonttools : 4.39.4
+        kiwisolver : 1.4.4
+             numpy : 1.24.3
+         packaging : 23.1
+            pillow : 9.5.0
+         pyparsing : 3.0.9
+   python-dateutil : 2.8.2
+--------------------------------------------------------------------------------
 ```
 
 Simply type
@@ -390,7 +415,6 @@ scooby --help
 ```
 
 to see all the possibilities.
-
 
 ## Optional Requirements
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,8 @@ distribution requirements with the `AutoReport` class:
 ```py
 >>> import scooby
 >>> scooby.AutoReport('matplotlib')
-
+```
+```
 --------------------------------------------------------------------------------
   Date: Fri Oct 20 16:49:34 2023 PDT
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,43 @@ installed, it will raise the following exception:
            `conda install -c conda-forge scooby`.
 ```
 
+### Autogenerate Reports for any Packages
+
+Scooby can automatically generate a Report for any package and its
+distribution requirements with the `AutoReport` class:
+
+```py
+>>> import scooby
+>>> scooby.AutoReport('matplotlib')
+
+--------------------------------------------------------------------------------
+  Date: Fri Oct 20 16:49:34 2023 PDT
+
+                OS : Darwin
+            CPU(s) : 8
+           Machine : arm64
+      Architecture : 64bit
+               RAM : 16.0 GiB
+       Environment : Python
+       File system : apfs
+
+  Python 3.11.3 | packaged by conda-forge | (main, Apr  6 2023, 08:58:31)
+  [Clang 14.0.6 ]
+
+        matplotlib : 3.7.1
+         contourpy : 1.0.7
+            cycler : 0.11.0
+         fonttools : 4.39.4
+        kiwisolver : 1.4.4
+             numpy : 1.24.3
+         packaging : 23.1
+            pillow : 9.5.0
+         pyparsing : 3.0.9
+   python-dateutil : 2.8.2
+--------------------------------------------------------------------------------
+>>>
+```
+
 ### Solving Mysteries
 
 Are you struggling with the mystery of whether or not code is being executed in
@@ -382,29 +419,30 @@ we can generate a Report for `matplotlib` and its dependencies:
 ```bash
 $ scooby -r matplotlib
 --------------------------------------------------------------------------------
-  Date: Fri Oct 20 16:28:13 2023 PDT
+  Date: Fri Oct 20 17:03:45 2023 PDT
 
-                OS : Darwin
-            CPU(s) : 8
-           Machine : arm64
-      Architecture : 64bit
-               RAM : 16.0 GiB
-       Environment : Python
-       File system : apfs
+                 OS : Darwin
+             CPU(s) : 8
+            Machine : arm64
+       Architecture : 64bit
+                RAM : 16.0 GiB
+        Environment : Python
+        File system : apfs
 
   Python 3.11.3 | packaged by conda-forge | (main, Apr  6 2023, 08:58:31)
   [Clang 14.0.6 ]
 
-        matplotlib : 3.7.1
-         contourpy : 1.0.7
-            cycler : 0.11.0
-         fonttools : 4.39.4
-        kiwisolver : 1.4.4
-             numpy : 1.24.3
-         packaging : 23.1
-            pillow : 9.5.0
-         pyparsing : 3.0.9
-   python-dateutil : 2.8.2
+         matplotlib : 3.7.1
+          contourpy : 1.0.7
+             cycler : 0.11.0
+          fonttools : 4.39.4
+         kiwisolver : 1.4.4
+              numpy : 1.24.3
+          packaging : 23.1
+             pillow : 9.5.0
+          pyparsing : 3.0.9
+    python-dateutil : 2.8.2
+importlib-resources : 5.12.0
 --------------------------------------------------------------------------------
 ```
 

--- a/README.md
+++ b/README.md
@@ -292,7 +292,6 @@ distribution requirements with the `AutoReport` class:
          pyparsing : 3.0.9
    python-dateutil : 2.8.2
 --------------------------------------------------------------------------------
->>>
 ```
 
 ### Solving Mysteries

--- a/README.md
+++ b/README.md
@@ -364,8 +364,8 @@ scooby
 ```
 
 in a terminal will display the default report. You can also use the CLI to show
-the scooby Report of another package if that package has scooby implemented as
-suggested above, using `packagename.Report()`.
+the scooby Report of another package if that package has implemented a Report
+class as suggested above, using `packagename.Report()`.
 
 As an example, to print the report of pyvista you can run
 
@@ -373,11 +373,11 @@ As an example, to print the report of pyvista you can run
 scooby -r pyvista
 ```
 
-which will show the report implemented in PyVista.
+which will show the Report implemented in PyVista.
 
 The CLI can also generate a report based on the dependencies of a package's
-distribution where that package hasn't implemented a report class. For example,
-we can generate a Report on `matplotlib` and its dependencies:
+distribution where that package hasn't implemented a Report class. For example,
+we can generate a Report for `matplotlib` and its dependencies:
 
 ```bash
 $ scooby -r matplotlib

--- a/README.md
+++ b/README.md
@@ -364,15 +364,24 @@ scooby
 ```
 
 in a terminal will display the default report. You can also use it to show the
-scooby-report of another package, if that package has scooby implemented as
-suggested above, using `packagename.Report()`. As an example, to print the
-report of pyvista you can run
+scooby-report of another package: if that package has scooby implemented as
+suggested above, using `packagename.Report()`, otherwise it will get that
+packages dependences from its distribution to generate a report.
+
+As an example, to print the report of pyvista you can run
 
 ```bash
 scooby --report pyvista
 ```
 
-which will show the report of PyVista.
+which will show the report implemented in PyVista.
+
+Or you could generate a report of a package and its dependencies that hasn't
+implemented a report class:
+
+```bash
+scooby --report matplotlib
+```
 
 Simply type
 

--- a/scooby/__init__.py
+++ b/scooby/__init__.py
@@ -22,12 +22,13 @@ from scooby.knowledge import (  # noqa
     meets_version,
     version_tuple,
 )
-from scooby.report import Report, get_version
+from scooby.report import AutoReport, Report, get_version
 from scooby.tracker import TrackedReport, track_imports, untrack_imports
 
 doo = Report
 
 __all__ = [
+    'AutoReport',
     'Report',
     'TrackedReport',
     'doo',

--- a/scooby/__main__.py
+++ b/scooby/__main__.py
@@ -4,8 +4,6 @@ import importlib
 import sys
 from typing import Any, Dict, List, Optional
 
-import pkg_resources
-
 import scooby
 from scooby.report import Report
 
@@ -85,10 +83,18 @@ def act(args_dict: Dict[str, Any]) -> None:
             pass
 
         try:
+            import pkg_resources
+
             # Generate our own report based on package requirements
             dist = pkg_resources.get_distribution(report)
             dist.requires()
             packages = [report] + [pkg.name for pkg in dist.requires()] + packages
+        except ImportError:
+            print(
+                f"Package `{report}` has no report and `pkg_resources` could not be used to autogenerate one.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         except pkg_resources.DistributionNotFound:
             print(f"Package `{report}` has no distribution or Report class.", file=sys.stderr)
             sys.exit(1)

--- a/scooby/__main__.py
+++ b/scooby/__main__.py
@@ -88,7 +88,7 @@ def act(args_dict: Dict[str, Any]) -> None:
             packages = [report, *dist_deps, *packages]
         except ImportError:
             print(
-                f"Package `{report}` has no Report class and `pkg_resources` could not be used to autogenerate one.",
+                f"Package `{report}` has no Report class and `importlib` could not be used to autogenerate one.",
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/scooby/__main__.py
+++ b/scooby/__main__.py
@@ -1,6 +1,7 @@
 """Create entry point for the command-line interface (CLI)."""
 import argparse
 import importlib
+from importlib.metadata import PackageNotFoundError
 import sys
 from typing import Any, Dict, List, Optional
 
@@ -86,7 +87,7 @@ def act(args_dict: Dict[str, Any]) -> None:
         try:
             dist_deps = get_distribution_dependencies(report)
             packages = [report, *dist_deps, *packages]
-        except ImportError:
+        except PackageNotFoundError:
             print(
                 f"Package `{report}` has no Report class and `importlib` could not be used to autogenerate one.",
                 file=sys.stderr,

--- a/scooby/__main__.py
+++ b/scooby/__main__.py
@@ -4,6 +4,8 @@ import importlib
 import sys
 from typing import Any, Dict, List, Optional
 
+import pkg_resources
+
 import scooby
 from scooby.report import Report
 
@@ -31,8 +33,8 @@ def main(args: Optional[List[str]] = None):
     parser.add_argument(
         "--no-opt",
         action="store_true",
-        default=False,
-        help="do not show the default optional packages",
+        default=None,
+        help="do not show the default optional packages. Defaults to True if using --report and defaults to False otherwise.",
     )
 
     # arg: Sort
@@ -45,7 +47,7 @@ def main(args: Optional[List[str]] = None):
 
     # arg: Version
     parser.add_argument(
-        "--version", action="store_true", default=False, help="only display scooby version"
+        "--version", "-v", action="store_true", default=False, help="only display scooby version"
     )
 
     # Call act with command line arguments as dict.
@@ -59,32 +61,48 @@ def act(args_dict: Dict[str, Any]) -> None:
         print(f"scooby v{scooby.__version__}")
         return
 
-    # Report of another package.
     report = args_dict.pop('report')
+    no_opt = args_dict.pop('no_opt')
+    packages = args_dict.pop('packages')
+
+    if no_opt is None and report is None:
+        no_opt = False
+    elif no_opt is None:
+        no_opt = True
+
+    # Report of another package.
     if report:
         try:
             module = importlib.import_module(report)
         except ImportError:
             print(f"Package `{report}` could not be imported.", file=sys.stderr)
-            return
+            sys.exit(1)
 
         try:
             print(module.Report())
+            return
         except AttributeError:
-            print(f"Package `{report}` has no attribute `Report()`.", file=sys.stderr)
+            pass
 
-    # Scooby report with additional options.
-    else:
-        # Collect input.
-        inp = {'additional': args_dict['packages'], 'sort': args_dict['sort']}
+        try:
+            # Generate our own report based on package requirements
+            dist = pkg_resources.get_distribution(report)
+            dist.requires()
+            packages = [report] + [pkg.name for pkg in dist.requires()] + packages
+        except pkg_resources.DistributionNotFound:
+            print(f"Package `{report}` has no distribution or Report class.", file=sys.stderr)
+            sys.exit(1)
 
-        # Define optional as empty list if no-opt.
-        if args_dict['no_opt']:
-            inp['optional'] = []
+    # Collect input.
+    inp = {'additional': packages, 'sort': args_dict['sort']}
 
-        # Print the report.
-        print(Report(**inp))
+    # Define optional as empty list if no-opt.
+    if no_opt:
+        inp['optional'] = []
+
+    # Print the report.
+    print(Report(**inp))
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/scooby/__main__.py
+++ b/scooby/__main__.py
@@ -24,7 +24,7 @@ def main(args: Optional[List[str]] = None):
 
     # arg: Report of a package
     parser.add_argument(
-        "--report", default=None, type=str, help=("print `Report()` of this package")
+        "--report", "-r", default=None, type=str, help=("print `Report()` of this package")
     )
 
     # arg: Sort

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -1,7 +1,7 @@
 """The main module containing the `Report` class."""
 
 import importlib
-from importlib.metadata import PackageNotFoundError, version as importlib_version
+from importlib.metadata import PackageNotFoundError, distribution, version as importlib_version
 import sys
 import time
 from types import ModuleType
@@ -563,11 +563,7 @@ def get_distribution_dependencies(dist_name: str):
         List of dependency names.
     """
     try:
-        import pkg_resources
-    except ImportError:
-        raise ImportError('Package `pkg_resources` could not be imported.')
-    try:
-        dist = pkg_resources.get_distribution(dist_name)
-    except pkg_resources.DistributionNotFound:
+        dist = distribution(dist_name)
+    except PackageNotFoundError:
         raise ImportError(f"Package `{dist_name}` has no distribution.")
-    return [pkg.name for pkg in dist.requires()]
+    return [pkg.split()[0] for pkg in dist.requires]

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -512,3 +512,27 @@ def platform() -> ModuleType:
     import platform
 
     return platform
+
+
+def get_distribution_dependencies(dist_name: str):
+    """Get the dependencies of a specified package distribution.
+
+    Parameters
+    ----------
+    dist_name : str
+        Name of the package distribution.
+
+    Returns
+    -------
+    dependencies : list
+        List of dependency names.
+    """
+    try:
+        import pkg_resources
+    except ImportError:
+        raise ImportError('Package `pkg_resources` could not be imported.')
+    try:
+        dist = pkg_resources.get_distribution(dist_name)
+    except pkg_resources.DistributionNotFound:
+        raise ImportError(f"Package `{dist_name}` has no distribution.")
+    return [pkg.name for pkg in dist.requires()]

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -455,7 +455,7 @@ class AutoReport(Report):
                 package.Report.__init__(
                     self, additional=additional, ncol=ncol, text_width=text_width, sort=sort
                 )
-        except (AttributeError, TypeError):
+        except (AttributeError, ImportError):
             # Autogenerate from distribution requirements
             core = [module, *get_distribution_dependencies(module)]
             Report.__init__(
@@ -565,5 +565,5 @@ def get_distribution_dependencies(dist_name: str):
     try:
         dist = distribution(dist_name)
     except PackageNotFoundError:
-        raise ImportError(f"Package `{dist_name}` has no distribution.")
+        raise PackageNotFoundError(f"Package `{dist_name}` has no distribution.")
     return [pkg.split()[0] for pkg in dist.requires]

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -434,6 +434,41 @@ class Report(PlatformInfo, PythonInfo):
         return out
 
 
+class AutoReport(Report):
+    """Auto-generate a scooby.Report for a package.
+
+    This will check if the specified package has a ``Report`` class and use that or
+    fallback to generating a report based on the distribution requirements of the package.
+    """
+
+    def __init__(self, module, additional=None, ncol=3, text_width=80, sort=False):
+        """Initialize."""
+        if not isinstance(module, (str, ModuleType)):
+            raise TypeError("Cannot generate report for type " "({})".format(type(module)))
+
+        if isinstance(module, ModuleType):
+            module = module.__name__
+
+        try:
+            package = importlib.import_module(module)
+            if issubclass(package.Report, Report):
+                package.Report.__init__(
+                    self, additional=additional, ncol=ncol, text_width=text_width, sort=sort
+                )
+        except (AttributeError, TypeError):
+            # Autogenerate from distribution requirements
+            core = [module, *get_distribution_dependencies(module)]
+            Report.__init__(
+                self,
+                additional=additional,
+                core=core,
+                optional=[],
+                ncol=ncol,
+                text_width=text_width,
+                sort=sort,
+            )
+
+
 # This functionaliy might also be of interest on its own.
 def get_version(module: Union[str, ModuleType]) -> Tuple[str, Optional[str]]:
     """Get the version of ``module`` by passing the package or it's name.

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -262,7 +262,7 @@ def test_cli(script_runner):
     # handle error -- no distribution
     ret = script_runner.run(['scooby', '--report', 'pathlib'])
     assert not ret.success
-    assert "no distribution" in ret.stderr
+    assert "pkg_resources" in ret.stderr
 
     # handle error -- not found
     ret = script_runner.run(['scooby', '--report', 'foobar'])

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -254,10 +254,10 @@ def test_cli(script_runner):
     assert "scooby v" in ret.stdout
 
     # default: scooby-Report for matplotlibe
-    ret = script_runner.run(['scooby', '--report', 'matplotlib'])
+    ret = script_runner.run(['scooby', '--report', 'pytest'])
     assert ret.success
-    assert "matplotlib" in ret.stdout
-    assert "cycler" in ret.stdout
+    assert "pytest" in ret.stdout
+    assert "iniconfig" in ret.stdout
 
     # handle error -- no distribution
     ret = script_runner.run(['scooby', '--report', 'pathlib'])

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -252,3 +252,19 @@ def test_cli(script_runner):
     ret = script_runner.run(['python', os.path.join('scooby', '__main__.py'), '--version'])
     assert ret.success
     assert "scooby v" in ret.stdout
+
+    # default: scooby-Report for matplotlibe
+    ret = script_runner.run(['scooby', '--report', 'matplotlib'])
+    assert ret.success
+    assert "matplotlib" in ret.stdout
+    assert "cycler" in ret.stdout
+
+    # handle error -- no distribution
+    ret = script_runner.run(['scooby', '--report', 'pathlib'])
+    assert not ret.success
+    assert "no distribution" in ret.stderr
+
+    # handle error -- not found
+    ret = script_runner.run(['scooby', '--report', 'foobar'])
+    assert not ret.success
+    assert "could not be imported" in ret.stderr

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -262,9 +262,15 @@ def test_cli(script_runner):
     # handle error -- no distribution
     ret = script_runner.run(['scooby', '--report', 'pathlib'])
     assert not ret.success
-    assert "pkg_resources" in ret.stderr
+    assert "importlib" in ret.stderr
 
     # handle error -- not found
     ret = script_runner.run(['scooby', '--report', 'foobar'])
     assert not ret.success
     assert "could not be imported" in ret.stderr
+
+
+def test_auto_report():
+    report = scooby.AutoReport('pytest')
+    assert 'pytest' in report.packages
+    assert 'iniconfig' in report.packages


### PR DESCRIPTION
The CLI that @prisae implemented is awesome! 

I found myself wanting to take it a step further. I wanted scooby to generate insightful reports about packages that do not have a `Report` class implemented directly.

These changes let the CLI fallback to using `pkg_resources` to get the distribution requirements to autogenerate a report about the specified package and its direct dependencies.

For example, `matplotlib`

```bash
$ scooby -r matplotlib

--------------------------------------------------------------------------------
  Date: Fri Oct 20 00:27:27 2023 PDT

                OS : Darwin
            CPU(s) : 8
           Machine : arm64
      Architecture : 64bit
               RAM : 16.0 GiB
       Environment : Python
       File system : apfs

  Python 3.11.3 | packaged by conda-forge | (main, Apr  6 2023, 08:58:31)
  [Clang 14.0.6 ]

        matplotlib : 3.7.1
         contourpy : 1.0.7
            cycler : 0.11.0
         fonttools : 4.39.4
        kiwisolver : 1.4.4
             numpy : 1.24.3
         packaging : 23.1
            pillow : 9.5.0
         pyparsing : 3.0.9
   python-dateutil : 2.8.2
--------------------------------------------------------------------------------
```


## Other Changes

- Fixes `sys.exit()` calls so that errors actually provide an error code to the shell
- Altered default of `--no-opt` arg