### PR TITLE
ENH. Add name and version of current linux distribution. 

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -18,4 +18,6 @@ ignore =
     # Quotes (temporary)
     Q0,
     # bare excepts (temporary)
-    B001, E722
+    B001, E722,
+    # Ignore "black" formatting errors, since black is already checked
+    BLK100

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -34,21 +34,32 @@ class PlatformInfo:
     def system(self) -> str:
         """Return the system/OS name.
 
-        E.g. ``'Linux (name version)'``, ``'Windows'``, or ``'Java'``. An empty string is
+        E.g. ``'Linux (name version)'``, ``'Windows'``, or ``'Darwin'``. An empty string is
         returned if the value cannot be determined.
         """
         s = platform().system()
         if s == 'Linux':
-            s += f' ({platform().freedesktop_os_release()["NAME"]} ' +\
-                 f'{platform().freedesktop_os_release()["VERSION_ID"]})'
+            try:
+                s += (
+                    f' ({platform().freedesktop_os_release()["NAME"]} '
+                    + f'{platform().freedesktop_os_release()["VERSION_ID"]})'
+                )
+            except Exception:
+                pass
         elif s == 'Windows':
-            # parse platform().win32_ver()
-            pass
-        elif s == 'Mac':
-            # parse platform().mac_ver()
-            pass
+            try:
+                release, version, csd, ptype = platform().win32_ver()
+                s += f' ({release} {version} {csd} {ptype})'
+            except Exception:
+                pass
+        elif s == 'Darwin':
+            try:
+                release, _, _ = platform().mac_ver()
+                s += f' (macOS {release})'
+            except Exception:
+                pass
         elif s == 'Java':
-            # parse platform().java_ver()
+            # TODO: parse platform().java_ver()
             pass
         return s
 

--- a/scooby/report.py
+++ b/scooby/report.py
@@ -34,10 +34,23 @@ class PlatformInfo:
     def system(self) -> str:
         """Return the system/OS name.
 
-        E.g. ``'Linux'``, ``'Windows'``, or ``'Java'``. An empty string is
+        E.g. ``'Linux (name version)'``, ``'Windows'``, or ``'Java'``. An empty string is
         returned if the value cannot be determined.
         """
-        return platform().system()
+        s = platform().system()
+        if s == 'Linux':
+            s += f' ({platform().freedesktop_os_release()["NAME"]} ' +\
+                 f'{platform().freedesktop_os_release()["VERSION_ID"]})'
+        elif s == 'Windows':
+            # parse platform().win32_ver()
+            pass
+        elif s == 'Mac':
+            # parse platform().mac_ver()
+            pass
+        elif s == 'Java':
+            # parse platform().java_ver()
+            pass
+        return s
 
     @property
     def platform(self) -> str:


### PR DESCRIPTION
It would be nice and helpful if we also have the name and version for the Linux distribution under OS .  It looks like this for my os.

```
--------------------------------------------------------------------------------
  Date: Thu Apr 18 18:36:14 2024 CEST

                OS : Linux (Gentoo 2.14)
            CPU(s) : 32
           Machine : x86_64
      Architecture : 64bit
               RAM : 62.6 GiB
       Environment : Python
       File system : ext4

  Python 3.11.8 (main, Mar 21 2024, 00:53:58) [GCC 13.2.1 20240113]

             numpy : 1.26.3
             scipy : 1.12.0
           IPython : 8.21.0
        matplotlib : 3.8.2
            scooby : 0.9.2
--------------------------------------------------------------------------------
```

The PR adds some placeholder for other platforms (Mac/Windows/Java) and would need some parsing for these platforms. I don't have access to them to test.

Thanks for considering this PR.

Cheers 
Carsten