### PR TITLE
Fix sorting packages with Report

### DIFF
--- a/scooby/report.py
+++ b/scooby/report.py
@@ -328,7 +328,7 @@ class Report(PlatformInfo, PythonInfo):
             text += '\n'
 
         # Loop over packages
-        for name, version in self._packages.items():
+        for name, version in self.packages.items():
             text += f'{name:>{row_width}} : {version}\n'
 
         # MKL details


### PR DESCRIPTION
Accessing `Report.packages` with the public API is required in order for the package sorting to be triggered. Currently, `Report._packages` is instead accessed, and thus no sorting occurs. This PR fixes this.

EDIT:
Reproducible with
``` python
import pyvista as pv
pv.Report(sort=True)
```

The packages will _not_ be sorted.