### PR TITLE
Report time in UTC timezone

### DIFF
--- a/scooby/report.py
+++ b/scooby/report.py
@@ -1,9 +1,9 @@
 """The main module containing the `Report` class."""
 
+from datetime import datetime, timezone
 import importlib
 from importlib.metadata import PackageNotFoundError, distribution, version as importlib_version
 import sys
-import time
 from types import ModuleType
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union, cast
 
@@ -140,7 +140,8 @@ class PlatformInfo:
     @property
     def date(self) -> str:
         """Return the date formatted as a string."""
-        return time.strftime('%a %b %d %H:%M:%S %Y %Z')
+        now_utc = datetime.now(timezone.utc)
+        return now_utc.strftime('%a %b %d %H:%M:%S %Y %Z')
 
     @property
     def filesystem(self) -> Union[str, Literal[False]]:

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -50,6 +50,10 @@ def test_report():
     report = scooby.Report(additional=['collections', 'foo', 'aaa'], sort=True)
 
 
+def test_timezone():
+    assert 'UTC' in str(scooby.Report())
+
+
 def test_dict():
     report = scooby.Report(['no_version', 'does_not_exist'])
     for key, value in report.to_dict().items():

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -1,5 +1,5 @@
-import os
 import datetime
+import os
 import re
 import subprocess
 import sys
@@ -60,7 +60,7 @@ def test_timezone(monkeypatch):
             return datetime.datetime(
                 2025, 1, 1, 12, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(hours=-5))
             )
-    
+
     monkeypatch.setattr(datetime, "datetime", FixedDatetime)
     assert 'UTC' in str(scooby.Report())
 

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -1,4 +1,5 @@
 import os
+import datetime
 import re
 import subprocess
 import sys
@@ -50,7 +51,15 @@ def test_report():
     report = scooby.Report(additional=['collections', 'foo', 'aaa'], sort=True)
 
 
-def test_timezone():
+def test_timezone(monkeypatch):
+    # Patch datetime to simulate non-UTC system time
+    class FixedDatetime(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            # Return a fixed time in, e.g., US/Eastern (UTC-5)
+            return datetime.datetime(2025, 1, 1, 12, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(hours=-5)))
+    
+    monkeypatch.setattr(datetime, "datetime", FixedDatetime)
     assert 'UTC' in str(scooby.Report())
 
 

--- a/tests/test_scooby.py
+++ b/tests/test_scooby.py
@@ -57,7 +57,9 @@ def test_timezone(monkeypatch):
         @classmethod
         def now(cls, tz=None):
             # Return a fixed time in, e.g., US/Eastern (UTC-5)
-            return datetime.datetime(2025, 1, 1, 12, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(hours=-5)))
+            return datetime.datetime(
+                2025, 1, 1, 12, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(hours=-5))
+            )
     
     monkeypatch.setattr(datetime, "datetime", FixedDatetime)
     assert 'UTC' in str(scooby.Report())


### PR DESCRIPTION
Show the timezone in UTC since it makes the reports more consistent and is also a bit more private since it won't implicitly reveal geographic location.