### PR TITLE
Fix distribution dependencies for excluded versions and uniqueness

### DIFF
--- a/scooby/report.py
+++ b/scooby/report.py
@@ -585,8 +585,9 @@ def get_distribution_dependencies(dist_name: str):
         raise PackageNotFoundError(f"Package `{dist_name}` has no distribution.")
 
     def _package_name(requirement: str) -> str:
-        for sep in (" ", ";", "<", "=", ">"):
+        for sep in (" ", ";", "<", "=", ">", "!"):
             requirement = requirement.split(sep, 1)[0]
         return requirement.strip()
 
-    return [_package_name(pkg) for pkg in dist.requires]
+    # Use dict for ordered and unique keys
+    return list({_package_name(pkg): None for pkg in dist.requires}.keys())


### PR DESCRIPTION
`get_distribution_dependencies` currently fails to parse excluded versions, e.g. `'x!=0.1'`, and also includes redundant packages, e.g. `['x!=0.1', 'x!=0.2']` gets parsed as `['x', 'x']` (i.e. it's included twice).

E.g.
``` py
>>> import scooby.report
>>> print(scooby.report.get_distribution_dependencies('pyvista'))
['matplotlib', 'numpy', 'pillow', 'pooch', 'scooby', 'typing-extensions', 'vtk!', 'vtk!', 'vtk', 'pyvista[colormaps,io,jupyter]', 'cmcrameri', 'cmocean', 'colorcet', 'imageio', 'meshio', 'ipywidgets', 'jupyter-server-proxy', 'nest_asyncio', 'trame-client', 'trame-server', 'trame-vtk', 'trame-vuetify', 'trame']
```


this PR fixes this.